### PR TITLE
fix #15 / added `N->` syntax to specify submatrix indices range from N to end

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,5 +10,5 @@ lazy val root = (project in file(".")).settings(
               "org.nd4j" % "nd4j-jblas" % "0.0.3.5.5.6-SNAPSHOT" % Test,
               "org.scalatest" %% "scalatest" % "2.2.4" % Test
        ),
-       scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions", "-language:higherKinds")
+       scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions", "-language:higherKinds","-language:postfixOps")
 )

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -42,6 +42,8 @@ object Implicits {
         case ---> :: t =>
           val ellipsised = List.fill(originalShape.length - i - t.size)(->)
           modifyTargetIndices(ellipsised ::: t, i, acc)
+        case IntRangeFrom(from:Int) :: t =>
+          modifyTargetIndices(t, i + 1, from -> (originalShape(i)-1) :: acc)
         case (inr: IndexNumberRange) :: t =>
           modifyTargetIndices(t, i + 1, inr.asTuple :: acc)
         case Nil => acc.reverse
@@ -89,10 +91,17 @@ object Implicits {
     override def asTuple: (Int, Int) = (underlying, underlying)
   }
 
+  case class IntRangeFrom(underlying:Int) extends IndexRange{
+    def apply(i:Int):(Int,Int) = (underlying,i)
+  }
+
   implicit class TupleRange(val underlying: _root_.scala.Tuple2[Int, Int]) extends IndexNumberRange {
     override def asTuple: (Int, Int) = underlying
   }
 
+  implicit class IntRangeFromGen(val underlying:Int) extends AnyVal{
+    def -> = IntRangeFrom(underlying)
+  }
 }
 
 sealed trait IndexNumberRange extends IndexRange {

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -18,7 +18,7 @@ class RichNDArrayTest extends FlatSpec {
   it should "be able to extract a part of 2d matrix" in {
     val nd = List(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f).asNDArray(3, 3)
 
-    val extracted = nd(1->2, 0->1)
+    val extracted = nd(1 -> 2, 0 -> 1)
     assert(extracted.rows() == 2)
     assert(extracted.columns() == 2)
     assert(extracted.getFloat(0) == 2)
@@ -30,30 +30,34 @@ class RichNDArrayTest extends FlatSpec {
   it should "be able to extract a part of 3d matrix" in {
     val nd = (1f to 8f by 1).asNDArray(2, 2, 2)
 
-    val extracted = nd(0, 0->1, ->)
+    val extracted = nd(0, 0 -> 1, ->)
     assert(extracted.getFloat(0) == 1)
     assert(extracted.getFloat(1) == 3)
     assert(extracted.getFloat(2) == 5)
     assert(extracted.getFloat(3) == 7)
   }
 
-  it should "return original NDArray if indexRange is all" in{
-    val multi = (1f to 8f by 1).asNDArray(2,2,2)
-    val extracted = multi(->,->,->)
+  it should "return original NDArray if indexRange is all" in {
+    val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
+    val extracted = multi(->, ->, ->)
     assert(multi == extracted)
 
     val ellipsised = multi(--->)
     assert(ellipsised == multi)
   }
-  it should "accept partially ellipsis indices" in{
-    val multi = (1f to 8f by 1).asNDArray(2,2,2)
+  it should "accept partially ellipsis indices" in {
+    val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
 
-    val ellipsised = multi(--->,0)
-    val notEllipsised = multi(->,->,0)
+    val ellipsised = multi(--->, 0)
+    val notEllipsised = multi(->, ->, 0)
     assert(ellipsised == notEllipsised)
 
-    val ellipsisedAtEnd = multi(0,--->)
-    val notEllipsisedAtEnd = multi(0,->,->)
+    val ellipsisedAtEnd = multi(0, --->)
+    val notEllipsisedAtEnd = multi(0, ->, ->)
     assert(ellipsisedAtEnd == notEllipsisedAtEnd)
+
+    val ellipsisedOneHand = multi(0 ->, ->, ->)
+    val notEllipsisedOneHand = multi(->, ->, ->)
+    assert(ellipsisedOneHand == notEllipsisedOneHand)
   }
 }

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -37,7 +37,16 @@ class RichNDArrayTest extends FlatSpec {
     assert(extracted.getFloat(3) == 7)
   }
 
-  it should "return original NDArray if indexRange is all" in {
+  it should "return original NDArray if indexRange is all in 2d matrix" in {
+    val multi = (1f to 9f by 1).asNDArray(3, 3)
+    val extracted = multi(->, ->)
+    assert(multi == extracted)
+
+    val ellipsised = multi(--->)
+    assert(ellipsised == multi)
+  }
+
+  it should "return original NDArray if indexRange is all in 3d matrix" in {
     val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
     val extracted = multi(->, ->, ->)
     assert(multi == extracted)
@@ -45,6 +54,7 @@ class RichNDArrayTest extends FlatSpec {
     val ellipsised = multi(--->)
     assert(ellipsised == multi)
   }
+
   it should "accept partially ellipsis indices" in {
     val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
 


### PR DESCRIPTION
Finally, I could find a way to add `N->` syntax, not `N-->` as I mentioned at issue.

```scala
val ndArray = (1f to 9f by 1).asNDArray(3, 3)

assert(ndArray(1-> , --->) == ndArray(1->2, 0->2, 0->2))
```

Also I happen to find a bug in submatrix indices calcualtion and make this PR include its bug fix.