### PR TITLE
fix #13 / add step field to specify submatrix indices

### DIFF
--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -7,18 +7,18 @@ import org.nd4j.linalg.factory.Nd4j
 
 class RichNDArrayTest extends FlatSpec {
   "org.nd4j.api.Implicits.RichNDArray" should "provides forall checker" in {
-    val nd = Nd4j.create(Array(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f), Array(3, 3))
+    val ndArray = Nd4j.create(Array(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f), Array(3, 3))
 
     //check if all elements in nd meet the criteria.
-    assert(nd > 0)
-    assert(nd < 10)
-    assert(!(nd > 5))
+    assert(ndArray > 0)
+    assert(ndArray < 10)
+    assert(!(ndArray > 5))
   }
 
   it should "be able to extract a part of 2d matrix" in {
-    val nd = List(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f).asNDArray(3, 3)
+    val ndArray = List(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f).asNDArray(3, 3)
 
-    val extracted = nd(1 -> 2, 0 -> 1)
+    val extracted = ndArray(1 -> 2, 0 -> 1)
     assert(extracted.rows() == 2)
     assert(extracted.columns() == 2)
     assert(extracted.getFloat(0) == 2)
@@ -28,9 +28,9 @@ class RichNDArrayTest extends FlatSpec {
   }
 
   it should "be able to extract a part of 3d matrix" in {
-    val nd = (1f to 8f by 1).asNDArray(2, 2, 2)
+    val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
 
-    val extracted = nd(0, 0 -> 1, ->)
+    val extracted = ndArray(0, 0 -> 1, ->)
     assert(extracted.getFloat(0) == 1)
     assert(extracted.getFloat(1) == 3)
     assert(extracted.getFloat(2) == 5)
@@ -38,36 +38,51 @@ class RichNDArrayTest extends FlatSpec {
   }
 
   it should "return original NDArray if indexRange is all in 2d matrix" in {
-    val multi = (1f to 9f by 1).asNDArray(3, 3)
-    val extracted = multi(->, ->)
-    assert(multi == extracted)
+    val ndArray = (1f to 9f by 1).asNDArray(3, 3)
+    val extracted = ndArray(->, ->)
+    assert(ndArray == extracted)
 
-    val ellipsised = multi(--->)
-    assert(ellipsised == multi)
+    val ellipsised = ndArray(--->)
+    assert(ellipsised == ndArray)
   }
 
   it should "return original NDArray if indexRange is all in 3d matrix" in {
-    val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
-    val extracted = multi(->, ->, ->)
-    assert(multi == extracted)
+    val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
+    val extracted = ndArray(->, ->, ->)
+    assert(ndArray == extracted)
 
-    val ellipsised = multi(--->)
-    assert(ellipsised == multi)
+    val ellipsised = ndArray(--->)
+    assert(ellipsised == ndArray)
   }
 
   it should "accept partially ellipsis indices" in {
-    val multi = (1f to 8f by 1).asNDArray(2, 2, 2)
+    val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
 
-    val ellipsised = multi(--->, 0)
-    val notEllipsised = multi(->, ->, 0)
+    val ellipsised = ndArray(--->, 0)
+    val notEllipsised = ndArray(->, ->, 0)
     assert(ellipsised == notEllipsised)
 
-    val ellipsisedAtEnd = multi(0, --->)
-    val notEllipsisedAtEnd = multi(0, ->, ->)
+    val ellipsisedAtEnd = ndArray(0, --->)
+    val notEllipsisedAtEnd = ndArray(0, ->, ->)
     assert(ellipsisedAtEnd == notEllipsisedAtEnd)
 
-    val ellipsisedOneHand = multi(0 ->, ->, ->)
-    val notEllipsisedOneHand = multi(->, ->, ->)
+    val ellipsisedOneHand = ndArray(0 ->, ->, ->)
+    val notEllipsisedOneHand = ndArray(->, ->, ->)
     assert(ellipsisedOneHand == notEllipsisedOneHand)
+  }
+
+  it should "be able to extract submatrix with index range by step" in{
+    val ndArray = (1f to 9f by 1).asNDArray(3,3)
+
+    val extracted = ndArray(0->3 by 2,->)
+    val extractedWithRange = ndArray(0 to 3 by 2,->)
+
+    assert(extracted == extractedWithRange)
+    assert(extracted.getFloat(0) == 1)
+    assert(extracted.getFloat(1) == 3)
+    assert(extracted.getFloat(2) == 4)
+    assert(extracted.getFloat(3) == 6)
+    assert(extracted.getFloat(4) == 7)
+    assert(extracted.getFloat(5) == 9)
   }
 }


### PR DESCRIPTION
This adds following syntax for `step` like NumPy.

```scala
val ndArray = (1f to 9f by 1).asNDArray(3,3)
/*
 [[1.0, 4.0, 7.0]
 [2.0, 5.0, 8.0]
  ,[3.0, 6.0, 9.0]]
*/

val extracted = ndArray(0->3 by 2,->)
/*
[[1.0, 4.0, 7.0]
 [3.0, 6.0, 9.0]]
*/
```