### PR TITLE
fix #14 / allow negative indices to extract submatrix

### DIFF
--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -7,7 +7,6 @@ import _root_.scala.annotation.tailrec
 import _root_.scala.util.control.Breaks._
 
 object Implicits {
-
   implicit class RichINDArray(val underlying: INDArray) extends AnyVal {
     def forall(f: Double => Boolean): Boolean = {
       var result = true
@@ -35,38 +34,44 @@ object Implicits {
     */
     def subMatrix(target: IndexRange*): INDArray = {
       require(target.size <= underlying.shape().length, "Matrix dimension must be equal or larger than shape's dimension to extract.")
-      val originalShape = underlying.shape()
+      val originalShape = if (underlying.shape().head != 1 || underlying.shape().length != 2)
+        underlying.shape()
+      else
+        underlying.shape().drop(1)
+
       @tailrec
-      def modifyTargetIndices(input: List[IndexRange], i: Int, acc: List[Range]): List[Range] = input match {
-        case -> :: t => modifyTargetIndices(t, i + 1, (0 to (originalShape(i) - 1)) :: acc)
+      def modifyTargetIndices(input: List[IndexRange], i: Int, acc: List[DRange]): List[DRange] = input match {
+        case -> :: t => modifyTargetIndices(t, i + 1, DRange(0,originalShape(i) - 1,1) :: acc)
         case ---> :: t =>
           val ellipsised = List.fill(originalShape.length - i - t.size)(->)
           modifyTargetIndices(ellipsised ::: t, i, acc)
         case IntRangeFrom(from: Int) :: t =>
-          modifyTargetIndices(t, i + 1, (from to (originalShape(i) - 1)) :: acc)
+          val max = originalShape(i)
+          modifyTargetIndices(t, i + 1, DRange(from , max - 1,1, max) :: acc)
         case (inr: IndexNumberRange) :: t =>
-          modifyTargetIndices(t, i + 1, inr.asRange :: acc)
+          modifyTargetIndices(t, i + 1, inr.asRange(originalShape(i)) :: acc)
 
         case Nil => acc.reverse
       }
 
       val modifiedTarget = modifyTargetIndices(target.toList, 0, Nil)
-      val targetShape = modifiedTarget.map(r => (r.end - r.start)/r.step +1)
+      val targetShape = modifiedTarget.map(_.length)
 
       @tailrec
-      def calcIndices(tgt: List[Range], orgShape: List[Int], layerSize: Int, acc: List[Int]): List[Int] = {
+      def calcIndices(tgt: List[DRange], orgShape: List[Int], layerSize: Int, acc: List[Int]): List[Int] = {
         (tgt, orgShape) match {
           case (h :: t, hs :: ts) if acc.isEmpty =>
             calcIndices(t, ts, layerSize, h.toList)
           case (h :: t, hs :: ts) =>
             val thisLayer = layerSize * hs
-            calcIndices(t, ts, thisLayer, h.flatMap{i => acc.map(_ + thisLayer*i)}.toList)
+            calcIndices(t, ts, thisLayer, h.toList.flatMap { i => acc.map(_ + thisLayer * i)}.toList)
           case _ => acc
         }
       }
-      val indices = calcIndices(modifiedTarget.toList, underlying.shape().toList, 1, Nil)
+      val indices = calcIndices(modifiedTarget.toList, originalShape.toList, 1, Nil)
 
       val filtered = indices.map { i => underlying.getDouble(i)}
+
       Nd4j.create(filtered.toArray, targetShape.toArray.filterNot(_ <= 1))
     }
 
@@ -87,7 +92,7 @@ object Implicits {
   case object ---> extends IndexRange
 
   implicit class IntRange(val underlying: Int) extends IndexNumberRange {
-    override def asRange: Range = underlying to underlying
+    protected[api] override def asRange(max: => Int): DRange = DRange(underlying, underlying, 1, max)
 
     override def toString: String = s"$underlying"
   }
@@ -99,24 +104,42 @@ object Implicits {
   }
 
   implicit class TupleRange(val underlying: _root_.scala.Tuple2[Int, Int]) extends IndexNumberRange {
-    override def asRange: Range = underlying._1 to underlying._2
+    protected[api] override def asRange(max: => Int): DRange = DRange(underlying._1, underlying._2, 1, max)
 
     override def toString: String = s"${underlying._1}->${underlying._2}"
 
-    def by(i:Int) = new IndexRangeWrapper(underlying._1 to underlying._2 by i)
+    def by(i: Int) = new IndexRangeWrapper(underlying._1 to underlying._2 by i)
   }
 
   implicit class IntRangeFromGen(val underlying: Int) extends AnyVal {
     def -> = IntRangeFrom(underlying)
   }
 
-  implicit class IndexRangeWrapper(val underlying:Range) extends IndexNumberRange{
-    override def asRange: Range = underlying
+  implicit class IndexRangeWrapper(val underlying: Range) extends IndexNumberRange {
+    protected[api] override def asRange(max: => Int): DRange = DRange.from(underlying, max)
   }
 }
 
 sealed trait IndexNumberRange extends IndexRange {
-  def asRange: Range
+  protected[api] def asRange(max: => Int): DRange
 }
 
 sealed trait IndexRange
+
+private[api] case class DRange(startR: Int, endR: Int, step: Int, max: Int) {
+  lazy val (start, end) = {
+    val start = if (startR >= 0) startR else max + startR
+    val end = if (endR >= 0) endR else max + endR
+    (start,end)
+  }
+  lazy val length = (end - start) / step + 1
+
+  def toList: List[Int] = List.iterate(start, length)(_ + step)
+
+  override def toString: String = s"${getClass.getSimpleName}(start:$start,end:$end,step:$step,length:$length)"
+}
+
+private[api] object DRange extends {
+  def from(r: Range, max: => Int): DRange = DRange(r.start, r.end, r.step, max)
+  def apply(startR: Int, endR: Int, step: Int):DRange = DRange(startR,endR,step,Int.MinValue)
+}

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -84,5 +84,18 @@ class RichNDArrayTest extends FlatSpec {
     assert(extracted.getFloat(3) == 6)
     assert(extracted.getFloat(4) == 7)
     assert(extracted.getFloat(5) == 9)
+
+    val list = (0f to 9f by 1).asNDArray(10)
+    val filtered = list(-2 -> 9)
+    assert(filtered.length() == 2)
+    assert(filtered.getFloat(0) == 8)
+    assert(filtered.getFloat(1) == 9)
+
+    val nStep = list(-3 -> 4 by -1)
+    assert(nStep.length() == 4)
+    assert(nStep.getFloat(0) == 7)
+    assert(nStep.getFloat(1) == 6)
+    assert(nStep.getFloat(2) == 5)
+    assert(nStep.getFloat(3) == 4)
   }
 }


### PR DESCRIPTION
This allows negative indices as follows:
```scala
scala> val list = (0f to 9f by 1).asNDArray(10)
list: org.nd4j.linalg.api.ndarray.INDArray = 
[0.0, 1.0, 2.0, 3.0, , ..., 7.0, 8.0, 9.0]

scala> val filtered = list(-2 -> 9)
filtered: org.nd4j.linalg.api.ndarray.INDArray = 
[8.0, 9.0]
 
scala> val nStep = list(-3 -> 4 by -1)
nStep: org.nd4j.linalg.api.ndarray.INDArray = 
[7.0, 6.0, 5.0, 4.0]
```