### PR TITLE
fix #27 / follow ndarray indexing setting change from Fortran to C in nd4j

### DIFF
--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -1,7 +1,7 @@
 package org.nd4j.api
 
 import org.nd4j.linalg.api.ndarray.INDArray
-import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.linalg.factory.{NDArrayFactory, Nd4j}
 
 import _root_.scala.util.control.Breaks._
 
@@ -33,25 +33,29 @@ object Implicits {
   }
 
 
+  /*
+   Avoid using Numeric[T].toDouble(t:T) for sequence transformation in XXColl2INDArray to minimize memory consumption.
+   */
   implicit class floatColl2INDArray(val underlying: Seq[Float]) extends AnyVal {
+    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.toArray,shape,ord.value,offset)
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.toArray, shape.toArray)
+    def toNDArray:INDArray = Nd4j.create(underlying.toArray)
   }
 
   implicit class doubleColl2INDArray(val underlying: Seq[Double]) extends AnyVal {
+    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.toArray,shape,offset,ord.value)
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.toArray, shape.toArray)
+    def toNDArray:INDArray = Nd4j.create(underlying.toArray)
   }
 
-  implicit class int2Scalar(val underlying: Int) extends AnyVal {
-    def asScalar: INDArray = Nd4j.scalar(underlying)
+  implicit class intColl2INDArray(val underlying: Seq[Int]) extends AnyVal {
+    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.map(_.toFloat).toArray,shape,ord.value,offset)
+    def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.map(_.toFloat).toArray, shape.toArray)
+    def toNDArray:INDArray = Nd4j.create(underlying.map(_.toFloat).toArray)
   }
-  implicit class float2Scalar(val underlying: Float) extends AnyVal {
-    def asScalar: INDArray = Nd4j.scalar(underlying)
-  }
-  implicit class double2Scalar(val underlying: Double) extends AnyVal {
-    def asScalar: INDArray = Nd4j.scalar(underlying)
-  }
-  implicit class long2Scalar(val underlying: Long) extends AnyVal {
-    def asScalar: INDArray = Nd4j.scalar(underlying)
+
+  implicit class num2Scalar[T](val underlying: T)(implicit ev:Numeric[T]){
+    def tsScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
 
   case object -> extends IndexRange
@@ -80,6 +84,7 @@ object Implicits {
     protected[api] override def asRange(max: => Int): DRange = DRange.from(underlying, max)
   }
 
+  lazy val NDOrdering = org.nd4j.api.NDOrdering
 }
 
 sealed trait IndexNumberRange extends IndexRange {

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -10,10 +10,11 @@ object Implicits {
   implicit class RichINDArray(val underlying: INDArray) extends SliceableNDArray with OperatableNDArray {
     def forall(f: Double => Boolean): Boolean = {
       var result = true
+      val lv = underlying.linearView()
       breakable {
         for {
-          i <- 0 until underlying.length()
-        } if (!f(underlying.getDouble(i))) {
+          i <- 0 until lv.length()
+        } if (!f(lv.getDouble(i))) {
           result = false
           break()
         }
@@ -37,25 +38,31 @@ object Implicits {
    Avoid using Numeric[T].toDouble(t:T) for sequence transformation in XXColl2INDArray to minimize memory consumption.
    */
   implicit class floatColl2INDArray(val underlying: Seq[Float]) extends AnyVal {
-    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.toArray,shape,ord.value,offset)
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying.toArray, shape, ord.value, offset)
+
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.toArray, shape.toArray)
-    def toNDArray:INDArray = Nd4j.create(underlying.toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying.toArray)
   }
 
   implicit class doubleColl2INDArray(val underlying: Seq[Double]) extends AnyVal {
-    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.toArray,shape,offset,ord.value)
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying.toArray, shape, offset, ord.value)
+
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.toArray, shape.toArray)
-    def toNDArray:INDArray = Nd4j.create(underlying.toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying.toArray)
   }
 
   implicit class intColl2INDArray(val underlying: Seq[Int]) extends AnyVal {
-    def mkNDArray(shape:Array[Int],ord:NDOrdering = NDOrdering(Nd4j.order()),offset:Int=0):INDArray = Nd4j.create(underlying.map(_.toFloat).toArray,shape,ord.value,offset)
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying.map(_.toFloat).toArray, shape, ord.value, offset)
+
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.map(_.toFloat).toArray, shape.toArray)
-    def toNDArray:INDArray = Nd4j.create(underlying.map(_.toFloat).toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.toFloat).toArray)
   }
 
-  implicit class num2Scalar[T](val underlying: T)(implicit ev:Numeric[T]){
-    def tsScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
+  implicit class num2Scalar[T](val underlying: T)(implicit ev: Numeric[T]) {
+    def toScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
 
   case object -> extends IndexRange
@@ -82,6 +89,7 @@ object Implicits {
 
   implicit class IndexRangeWrapper(val underlying: Range) extends IndexNumberRange {
     protected[api] override def asRange(max: => Int): DRange = DRange.from(underlying, max)
+    override def toString: String = s"${underlying.start}->${underlying.end} by ${underlying.step}"
   }
 
   lazy val NDOrdering = org.nd4j.api.NDOrdering

--- a/src/main/scala/org/nd4j/api/NDOrdering.scala
+++ b/src/main/scala/org/nd4j/api/NDOrdering.scala
@@ -1,0 +1,20 @@
+package org.nd4j.api
+
+import org.nd4j.linalg.factory.NDArrayFactory
+
+sealed trait NDOrdering {
+  val value:Char
+}
+object NDOrdering{
+  case object Fortran extends NDOrdering{
+    override val value: Char = NDArrayFactory.FORTRAN
+  }
+  case object C extends NDOrdering{
+    override val value: Char = NDArrayFactory.C
+  }
+  def apply(char:Char):NDOrdering = char.toLower match{
+    case 'c' => C
+    case 'f' => Fortran
+    case _ => throw new IllegalArgumentException("NDimensional Ordering accepts only 'c' or 'f'.")
+  }
+}

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -7,26 +7,27 @@ import org.nd4j.linalg.factory.Nd4j
 import _root_.scala.annotation.tailrec
 
 trait SliceableNDArray {
-  val underlying:INDArray
+  val underlying: INDArray
+
   /*
  Extract subMatrix at given position.
   */
   def subMatrix(target: IndexRange*): INDArray = {
     require(target.size <= underlying.shape().length, "Matrix dimension must be equal or larger than shape's dimension to extract.")
-    val originalShape = if (underlying.shape().head != 1 || underlying.shape().length != 2)
-      underlying.shape()
-    else
+    val originalShape = if (underlying.isRowVector)
       underlying.shape().drop(1)
+    else
+      underlying.shape()
 
     @tailrec
     def modifyTargetIndices(input: List[IndexRange], i: Int, acc: List[DRange]): List[DRange] = input match {
-      case -> :: t => modifyTargetIndices(t, i + 1, DRange(0,originalShape(i) - 1,1) :: acc)
+      case -> :: t => modifyTargetIndices(t, i + 1, DRange(0, originalShape(i) - 1, 1) :: acc)
       case ---> :: t =>
         val ellipsised = List.fill(originalShape.length - i - t.size)(->)
         modifyTargetIndices(ellipsised ::: t, i, acc)
       case IntRangeFrom(from: Int) :: t =>
         val max = originalShape(i)
-        modifyTargetIndices(t, i + 1, DRange(from , max - 1,1, max) :: acc)
+        modifyTargetIndices(t, i + 1, DRange(from, max - 1, 1, max) :: acc)
       case (inr: IndexNumberRange) :: t =>
         modifyTargetIndices(t, i + 1, inr.asRange(originalShape(i)) :: acc)
 
@@ -34,23 +35,26 @@ trait SliceableNDArray {
     }
 
     val modifiedTarget = modifyTargetIndices(target.toList, 0, Nil)
-    val targetShape = modifiedTarget.map(_.length)
+    val targetShape =
+      if (underlying.isRowVector)
+        Array(1, modifiedTarget.head.length)
+      else
+        modifiedTarget.map(_.length).toArray
 
-    @tailrec
-    def calcIndices(tgt: List[DRange], orgShape: List[Int], layerSize: Int, acc: List[Int]): List[Int] = {
-      (tgt, orgShape) match {
-        case (h :: t, hs :: ts) if acc.isEmpty =>
-          calcIndices(t, ts, layerSize, h.toList)
-        case (h :: t, hs :: ts) =>
-          val thisLayer = layerSize * hs
-          calcIndices(t, ts, thisLayer, h.toList.flatMap { i => acc.map(_ + thisLayer * i)}.toList)
-        case _ => acc
-      }
+    (modifiedTarget zip underlying.stride()).collect {
+      case (range, stride) => range.toList
     }
-    val indices = calcIndices(modifiedTarget.toList, originalShape.toList, 1, Nil)
 
-    val filtered = indices.map { i => underlying.getDouble(i)}
+    def calcIndices(tgt: List[DRange], stride: List[Int]): List[Int] =
+      (tgt.reverse zip stride).collect {
+        case (range, st) => range.toList.map(_ * st)
+      }.reduceLeft[List[Int]] { case (l, r) => l.flatMap { i => r.map(_ + i)}}
 
-    Nd4j.create(filtered.toArray, targetShape.toArray.filterNot(_ <= 1))
+    val indices = calcIndices(modifiedTarget.toList, underlying.stride().toList)
+
+    val lv = underlying.linearView()
+    val filtered = indices.map { i => lv.getDouble(i)}
+
+    filtered.mkNDArray(targetShape, NDOrdering(underlying.ordering()), underlying.offset())
   }
 }

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -15,29 +15,62 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(!(ndArray > 5))
   }
 
-  it should "be able to extract a part of 2d matrix" in {
-    val ndArray = List(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f).asNDArray(3, 3)
+  it should "be able to extract a part of 2d matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
+    val ndArray = (1 to 9).asNDArray(3, 3)
 
     val extracted = ndArray(1 -> 2, 0 -> 1)
     assert(extracted.rows() == 2)
     assert(extracted.columns() == 2)
-    assert(extracted.getFloat(0) == 2)
-    assert(extracted.getFloat(1) == 3)
-    assert(extracted.getFloat(2) == 5)
-    assert(extracted.getFloat(3) == 6)
+
+    val lv = extracted.linearView()
+    assert(lv.getFloat(0) == 2)
+    assert(lv.getFloat(1) == 3)
+    assert(lv.getFloat(2) == 5)
+    assert(lv.getFloat(3) == 6)
   }
 
-  it should "be able to extract a part of 3d matrix" in {
-    val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
+  it should "be able to extract a part of 2d matrix in Fortran ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.Fortran.value)
+    val ndArray = (1 to 9).asNDArray(3, 3)
+
+    val extracted = ndArray(1 -> 2, 0 -> 1)
+    assert(extracted.rows() == 2)
+    assert(extracted.columns() == 2)
+
+    val lv = extracted.linearView()
+    assert(lv.getFloat(0) == 2)
+    assert(lv.getFloat(1) == 5)
+    assert(lv.getFloat(2) == 3)
+    assert(lv.getFloat(3) == 6)
+  }
+
+  it should "be able to extract a part of 3d matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
+    val ndArray = (1 to 8).asNDArray(2, 2, 2)
 
     val extracted = ndArray(0, 0 -> 1, ->)
-    assert(extracted.getFloat(0) == 1)
-    assert(extracted.getFloat(1) == 3)
-    assert(extracted.getFloat(2) == 5)
-    assert(extracted.getFloat(3) == 7)
+    val lv = extracted.linearView()
+    assert(lv.getFloat(0) == 1)
+    assert(lv.getFloat(1) == 3)
+    assert(lv.getFloat(2) == 5)
+    assert(lv.getFloat(3) == 7)
   }
 
-  it should "return original NDArray if indexRange is all in 2d matrix" in {
+  it should "be able to extract a part of 3d matrix in Fortran ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.Fortran.value)
+    val ndArray = (1 to 8).asNDArray(2, 2, 2)
+
+    val extracted = ndArray(0, 0 -> 1, ->)
+    val lv = extracted.linearView()
+    assert(lv.getFloat(0) == 1)
+    assert(lv.getFloat(1) == 5)
+    assert(lv.getFloat(2) == 3)
+    assert(lv.getFloat(3) == 7)
+  }
+
+  it should "return original NDArray if indexRange is all in 2d matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1f to 9f by 1).asNDArray(3, 3)
     val extracted = ndArray(->, ->)
     assert(ndArray == extracted)
@@ -46,7 +79,8 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(ellipsised == ndArray)
   }
 
-  it should "return original NDArray if indexRange is all in 3d matrix" in {
+  it should "return original NDArray if indexRange is all in 3d matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
     val extracted = ndArray(->, ->, ->)
     assert(ndArray == extracted)
@@ -55,7 +89,8 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(ellipsised == ndArray)
   }
 
-  it should "accept partially ellipsis indices" in {
+  it should "accept partially ellipsis indices in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
 
     val ellipsised = ndArray(--->, 0)
@@ -71,31 +106,39 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(ellipsisedOneHand == notEllipsisedOneHand)
   }
 
-  it should "be able to extract submatrix with index range by step" in{
+  it should "be able to extract submatrix with index range by step in C ordering" in{
+    Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1f to 9f by 1).asNDArray(3,3)
 
     val extracted = ndArray(0->3 by 2,->)
     val extractedWithRange = ndArray(0 to 3 by 2,->)
 
+    val lv = extracted.linearView()
     assert(extracted == extractedWithRange)
-    assert(extracted.getFloat(0) == 1)
-    assert(extracted.getFloat(1) == 3)
-    assert(extracted.getFloat(2) == 4)
-    assert(extracted.getFloat(3) == 6)
-    assert(extracted.getFloat(4) == 7)
-    assert(extracted.getFloat(5) == 9)
+    assert(lv.getFloat(0) == 1)
+    assert(lv.getFloat(1) == 3)
+    assert(lv.getFloat(2) == 4)
+    assert(lv.getFloat(3) == 6)
+    assert(lv.getFloat(4) == 7)
+    assert(lv.getFloat(5) == 9)
 
-    val list = (0f to 9f by 1).asNDArray(10)
-    val filtered = list(-2 -> 9)
+    val list = (0f to 9f by 1).asNDArray(1,10)
+    val filtered = list(-2 -> 9).linearView()
     assert(filtered.length() == 2)
     assert(filtered.getFloat(0) == 8)
     assert(filtered.getFloat(1) == 9)
 
-    val nStep = list(-3 -> 4 by -1)
+    val nStep = list(-3 -> 4 by -1).linearView()
     assert(nStep.length() == 4)
     assert(nStep.getFloat(0) == 7)
     assert(nStep.getFloat(1) == 6)
     assert(nStep.getFloat(2) == 5)
     assert(nStep.getFloat(3) == 4)
+  }
+
+  "num2Scalar" should "convert number to Scalar INDArray" in {
+    assert(1.toScalar == List(1).toNDArray)
+    assert(2f.toScalar == List(2).toNDArray)
+    assert(3d.toScalar == List(3).toNDArray)
   }
 }

--- a/src/test/scala/org/nd4j/api/linalg/RichNDArraySpec.scala
+++ b/src/test/scala/org/nd4j/api/linalg/RichNDArraySpec.scala
@@ -100,7 +100,6 @@ class RichNDArraySpec extends FlatSpec with Matchers {
   }
 
   it should "use === for equality comparisons" in {
-
     val a = Nd4j.create(Array[Double](1, 2))
 
     val b = Nd4j.create(Array[Double](1, 2))


### PR DESCRIPTION
This fixes the following bugs.
* the bug in slicing if ndarray is C ordering.
* the bug due to `INDArray#getFloat` spec change in nd4j matrix. (`INDArray#linearView#getFloat` has to be used instead.)