### PR TITLE
fix #30 / make test cases clearer visually / add syntax sugar to create NDArray from 2d array

### DIFF
--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -33,7 +33,6 @@ object Implicits {
     def apply(target: IndexRange*): INDArray = subMatrix(target: _*)
   }
 
-
   /*
    Avoid using Numeric[T].toDouble(t:T) for sequence transformation in XXColl2INDArray to minimize memory consumption.
    */
@@ -45,12 +44,28 @@ object Implicits {
     def toNDArray: INDArray = Nd4j.create(underlying.toArray)
   }
 
+  implicit class floatArray2INDArray(val underlying: Array[Float]) extends AnyVal {
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying, shape, ord.value, offset)
+
+    def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying, shape.toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying)
+  }
+
   implicit class doubleColl2INDArray(val underlying: Seq[Double]) extends AnyVal {
     def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying.toArray, shape, offset, ord.value)
 
     def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.toArray, shape.toArray)
 
     def toNDArray: INDArray = Nd4j.create(underlying.toArray)
+  }
+
+  implicit class doubleArray2INDArray(val underlying: Array[Double]) extends AnyVal {
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying, shape, offset, ord.value)
+
+    def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying, shape.toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying)
   }
 
   implicit class intColl2INDArray(val underlying: Seq[Int]) extends AnyVal {
@@ -61,6 +76,32 @@ object Implicits {
     def toNDArray: INDArray = Nd4j.create(underlying.map(_.toFloat).toArray)
   }
 
+  implicit class intArray2INDArray(val underlying: Array[Int]) extends AnyVal {
+    def mkNDArray(shape: Array[Int], ord: NDOrdering = NDOrdering(Nd4j.order()), offset: Int = 0): INDArray = Nd4j.create(underlying.map(_.toFloat), shape, ord.value, offset)
+
+    def asNDArray(shape: Int*): INDArray = Nd4j.create(underlying.map(_.toFloat), shape.toArray)
+
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.toFloat).toArray)
+  }
+
+  implicit class floatMtrix2INDArray(val underlying: Seq[Seq[Float]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.toArray).toArray)
+  }
+  implicit class floatArrayMtrix2INDArray(val underlying: Array[Array[Float]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying)
+  }
+  implicit class doubleMtrix2INDArray(val underlying: Seq[Seq[Double]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.toArray).toArray)
+  }
+  implicit class doubleArrayMtrix2INDArray(val underlying: Array[Array[Double]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying)
+  }
+  implicit class intMtrix2INDArray(val underlying: Seq[Seq[Int]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.map(_.toFloat).toArray).toArray)
+  }
+  implicit class intArrayMtrix2INDArray(val underlying: Array[Array[Int]]) extends AnyVal {
+    def toNDArray: INDArray = Nd4j.create(underlying.map(_.map(_.toFloat)))
+  }
   implicit class num2Scalar[T](val underlying: T)(implicit ev: Numeric[T]) {
     def toScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
@@ -124,6 +165,5 @@ private[api] case class DRange(startR: Int, endR: Int, isInclusive: Boolean, ste
 
 private[api] object DRange extends {
   def from(r: Range, max: => Int): DRange = DRange(r.start, r.end, r.isInclusive, r.step, max)
-
   def apply(startR: Int, endR: Int, step: Int): DRange = DRange(startR, endR, false, step, Int.MinValue)
 }

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -57,6 +57,6 @@ trait SliceableNDArray {
     val lv = underlying.linearView()
     val filtered = indices.map { i => lv.getDouble(i)}
 
-    filtered.mkNDArray(targetShape, NDOrdering(underlying.ordering()), underlying.offset())
+    filtered.mkNDArray(targetShape, NDOrdering(underlying.ordering()),0)
   }
 }

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -1,6 +1,7 @@
 package org.nd4j.api
 
 import org.nd4j.api.Implicits._
+import org.nd4j.api.NDOrdering.Fortran
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.nd4j.linalg.factory.Nd4j
 
@@ -31,10 +32,15 @@ trait SliceableNDArray {
       case (inr: IndexNumberRange) :: t =>
         modifyTargetIndices(t, i + 1, inr.asRange(originalShape(i)) :: acc)
 
-      case Nil => acc.reverse
+      case Nil =>
+        if(underlying.ordering() == NDOrdering.Fortran.value)
+          acc
+        else
+          acc.reverse
     }
 
     val modifiedTarget = modifyTargetIndices(target.toList, 0, Nil)
+
     val targetShape =
       if (underlying.isRowVector)
         Array(1, modifiedTarget.head.length)
@@ -42,7 +48,7 @@ trait SliceableNDArray {
         modifiedTarget.map(_.length).toArray
 
     def calcIndices(tgt: List[DRange], stride: List[Int]): List[Int] =
-      (tgt.reverse zip stride).collect {
+      (tgt zip stride).collect {
         case (range, st) => range.toList.map(_ * st)
       }.reduceLeft[List[Int]] { case (l, r) => l.flatMap { i => r.map(_ + i)}}
 

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -39,6 +39,38 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(extracted == expected)
   }
 
+  it should "be able to extract a part of 2d matrix in C ordering with offset" in {
+    val ndArray = (1 to 9).mkNDArray(Array(2, 2), NDOrdering.C, offset = 4)
+
+    val expectedArray = Array(
+      Array(5, 6),
+      Array(7, 8)
+    ).toNDArray
+    assert(ndArray == expectedArray)
+
+    val expectedSlice = Array(
+      Array(5),
+      Array(7)
+    ).toNDArray
+    assert(ndArray(->, 0) == expectedSlice)
+  }
+
+  it should "be able to extract a part of 2d matrix in F ordering with offset" in {
+    val ndArray = (1 to 9).mkNDArray(Array(2, 2), NDOrdering.Fortran, offset = 4)
+
+    val expectedArray = Array(
+      Array(5, 7),
+      Array(6, 8)
+    ).toNDArray
+    assert(ndArray == expectedArray)
+
+    val expectedSlice = Array(
+      Array(5),
+      Array(6)
+    ).toNDArray
+    assert(ndArray(->, 0) == expectedSlice)
+  }
+
   it should "be able to extract a part of vertically long matrix in C ordering" in {
     Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray =

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -7,7 +7,12 @@ import org.nd4j.linalg.factory.Nd4j
 
 class NDArrayExtractionTest extends FlatSpec {
   "org.nd4j.api.Implicits.RichNDArray" should "provides forall checker" in {
-    val ndArray = Nd4j.create(Array(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f), Array(3, 3))
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
 
     //check if all elements in nd meet the criteria.
     assert(ndArray > 0)
@@ -17,61 +22,105 @@ class NDArrayExtractionTest extends FlatSpec {
 
   it should "be able to extract a part of 2d matrix in C ordering" in {
     Nd4j.factory().setOrder(NDOrdering.C.value)
-    val ndArray = (1 to 9).asNDArray(3, 3)
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
 
     val extracted = ndArray(1 -> 3, 0 -> 2)
-    assert(extracted.rows() == 2)
-    assert(extracted.columns() == 2)
 
-    val lv = extracted.linearView()
-    assert(lv.getFloat(0) == 2)
-    assert(lv.getFloat(1) == 3)
-    assert(lv.getFloat(2) == 5)
-    assert(lv.getFloat(3) == 6)
+    val expected =
+      Array(
+        Array(4, 5),
+        Array(7, 8)
+      ).toNDArray
+    assert(extracted == expected)
+  }
+
+  it should "be able to extract a part of vertically long matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
+    val ndArray =
+      Array(
+        Array(1, 2),
+        Array(3, 4),
+        Array(5, 6),
+        Array(7, 8)
+      ).toNDArray
+
+    assert(ndArray(0 -> 2, ->) ==
+      Array(
+        Array(1, 2),
+        Array(3, 4)
+      ).toNDArray)
+
+    assert(ndArray(2 -> 4, ->) ==
+      Array(
+        Array(5, 6),
+        Array(7, 8)
+      ).toNDArray)
+  }
+
+  it should "be able to extract a part of horizontally long matrix in C ordering" in {
+    Nd4j.factory().setOrder(NDOrdering.C.value)
+    val ndArray =
+      Array(
+        Array(1, 2, 3, 4),
+        Array(5, 6, 7, 8)
+      ).toNDArray
+
+    assert(ndArray(->, 0 -> 2) ==
+      Array(
+        Array(1, 2),
+        Array(5, 6)
+      ).toNDArray)
+
+    assert(ndArray(->, 2 -> 4) ==
+      Array(
+        Array(3, 4),
+        Array(7, 8)
+      ).toNDArray)
   }
 
   it should "be able to extract a part of 2d matrix in Fortran ordering" in {
     Nd4j.factory().setOrder(NDOrdering.Fortran.value)
-    val ndArray = (1 to 9).asNDArray(3, 3)
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
 
     val extracted = ndArray(1 -> 3, 0 -> 2)
-    assert(extracted.rows() == 2)
-    assert(extracted.columns() == 2)
 
-    val lv = extracted.linearView()
-    assert(lv.getFloat(0) == 2)
-    assert(lv.getFloat(1) == 5)
-    assert(lv.getFloat(2) == 3)
-    assert(lv.getFloat(3) == 6)
+    val expected =
+      Array(
+        Array(4, 5),
+        Array(7, 8)
+      ).toNDArray
+    assert(extracted == expected)
   }
 
   it should "be able to extract a part of 3d matrix in C ordering" in {
     Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1 to 8).asNDArray(2, 2, 2)
 
-    val extracted = ndArray(0, 0 -> 2, ->)
+    val extracted = ndArray(0, ->, ->)
     val lv = extracted.linearView()
     assert(lv.getFloat(0) == 1)
-    assert(lv.getFloat(1) == 3)
-    assert(lv.getFloat(2) == 5)
-    assert(lv.getFloat(3) == 7)
-  }
-
-  it should "be able to extract a part of 3d matrix in Fortran ordering" in {
-    Nd4j.factory().setOrder(NDOrdering.Fortran.value)
-    val ndArray = (1 to 8).asNDArray(2, 2, 2)
-
-    val extracted = ndArray(0, 0 -> 2, ->)
-    val lv = extracted.linearView()
-    assert(lv.getFloat(0) == 1)
-    assert(lv.getFloat(1) == 5)
+    assert(lv.getFloat(1) == 2)
     assert(lv.getFloat(2) == 3)
-    assert(lv.getFloat(3) == 7)
+    assert(lv.getFloat(3) == 4)
   }
 
-  it should "return original NDArray if indexRange is all in 2d matrix in C ordering" in {
-    Nd4j.factory().setOrder(NDOrdering.C.value)
-    val ndArray = (1f to 9f by 1).asNDArray(3, 3)
+  it should "return original NDArray if indexRange is all in 2d matrix" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
     val extracted = ndArray(->, ->)
     assert(ndArray == extracted)
 
@@ -79,8 +128,7 @@ class NDArrayExtractionTest extends FlatSpec {
     assert(ellipsised == ndArray)
   }
 
-  it should "return original NDArray if indexRange is all in 3d matrix in C ordering" in {
-    Nd4j.factory().setOrder(NDOrdering.C.value)
+  it should "return original NDArray if indexRange is all in 3d matrix" in {
     val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
     val extracted = ndArray(->, ->, ->)
     assert(ndArray == extracted)
@@ -90,7 +138,6 @@ class NDArrayExtractionTest extends FlatSpec {
   }
 
   it should "accept partially ellipsis indices in C ordering" in {
-    Nd4j.factory().setOrder(NDOrdering.C.value)
     val ndArray = (1f to 8f by 1).asNDArray(2, 2, 2)
 
     val ellipsised = ndArray(--->, 0)
@@ -107,22 +154,26 @@ class NDArrayExtractionTest extends FlatSpec {
   }
 
   it should "be able to extract submatrix with index range by step in C ordering" in {
-    Nd4j.factory().setOrder(NDOrdering.C.value)
-    val ndArray = (1f to 9f by 1).asNDArray(3, 3)
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
 
     val extracted = ndArray(0 -> 3 by 2, ->)
     val extractedWithRange = ndArray(0 until 3 by 2, ->)
     val extractedWithInclusiveRange = ndArray(0 to 2 by 2, ->)
 
-    val lv = extracted.linearView()
-    assert(extracted == extractedWithRange)
-    assert(extracted == extractedWithInclusiveRange)
-    assert(lv.getFloat(0) == 1)
-    assert(lv.getFloat(1) == 3)
-    assert(lv.getFloat(2) == 4)
-    assert(lv.getFloat(3) == 6)
-    assert(lv.getFloat(4) == 7)
-    assert(lv.getFloat(5) == 9)
+    val expected =
+      Array(
+        Array(1, 2, 3),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    assert(extracted == expected)
+    assert(extractedWithRange == expected)
+    assert(extractedWithInclusiveRange == expected)
 
     /*
      Equivalent with NumPy document examples.
@@ -131,9 +182,9 @@ class NDArrayExtractionTest extends FlatSpec {
     val list = (0 to 9).toNDArray
     val step = list(1 -> 7 by 2).linearView()
     assert(step.length() == 3)
-    assert(step.getFloat(0)== 1)
-    assert(step.getFloat(1)== 3)
-    assert(step.getFloat(2)== 5)
+    assert(step.getFloat(0) == 1)
+    assert(step.getFloat(1) == 3)
+    assert(step.getFloat(2) == 5)
 
     val filtered = list(-2 -> 10).linearView()
     assert(filtered.length() == 2)


### PR DESCRIPTION
This fixes slice indexing bug, reported in #30.

This also adds following syntax.
```scala
scala> val ndArray =
      Array(
        Array(1, 2, 3),
        Array(4, 5, 6),
        Array(7, 8, 9)
      ).toNDArray

ndArray: org.nd4j.linalg.api.ndarray.INDArray = 
[[1.0, 2.0, 3.0]
 [4.0, 5.0, 6.0]
  ,[7.0, 8.0, 9.0]]
```

... and make test cases clearer in visual using this syntax.