### PR TITLE
fix #26 / added filter & map func like collection API

### DIFF
--- a/src/main/scala/org/nd4j/api/CollectionLikeNDArray.scala
+++ b/src/main/scala/org/nd4j/api/CollectionLikeNDArray.scala
@@ -1,0 +1,39 @@
+package org.nd4j.api
+
+import org.nd4j.api.ops._
+import org.nd4j.api.Implicits._
+import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+
+trait CollectionLikeNDArray {
+  val underlying: INDArray
+
+  def filteri(f: Double => Boolean): INDArray = notCleanedUp { array =>
+    Nd4j.getExecutioner.exec(FilterOps(underlying.linearView(), f)).z().reshape()reshape(underlying.shape():_*)
+  }
+  def filter(f: Double => Boolean): INDArray = underlying.dup().filteri(f)
+
+  def filterBiti(f: Double => Boolean): INDArray = notCleanedUp { array =>
+    Nd4j.getExecutioner.exec(BitFilterOps(underlying.linearView(), f)).z().reshape()reshape(underlying.shape():_*)
+  }
+
+  def filterBit(f: Double => Boolean): INDArray = underlying.dup().filterBiti(f)
+
+  def mapRCi(f: Double => Double)(g:IComplexNumber => IComplexNumber): INDArray = notCleanedUp { array =>
+    Nd4j.getExecutioner.exec(MapOps(underlying.linearView(), f,g)).z().reshape(underlying.shape():_*)
+  }
+  def mapRC(f: Double => Double)(g:IComplexNumber => IComplexNumber): INDArray = underlying.dup().mapRCi(f)(g)
+
+  def mapi(f: Double => Double): INDArray = mapRCi(f)(g => g)
+  def map(f: Double => Double): INDArray = mapRC(f)(g => g)
+
+  def mapCi(g:IComplexNumber => IComplexNumber): INDArray = mapRCi(f => f)(g)
+  def mapC(g:IComplexNumber => IComplexNumber): INDArray = mapRC(f => f)(g)
+
+  def notCleanedUp[A](f: INDArray => A): A = {
+    if (underlying.isCleanedUp)
+      throw new IllegalStateException("Invalid operation: already collected")
+    f(underlying)
+  }
+}

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -7,7 +7,7 @@ import _root_.scala.util.control.Breaks._
 
 object Implicits {
 
-  implicit class RichINDArray(val underlying: INDArray) extends SliceableNDArray with OperatableNDArray {
+  implicit class RichINDArray(val underlying: INDArray) extends SliceableNDArray with OperatableNDArray with CollectionLikeNDArray{
     def forall(f: Double => Boolean): Boolean = {
       var result = true
       val lv = underlying.linearView()

--- a/src/main/scala/org/nd4j/api/ops/BitFilterOps.scala
+++ b/src/main/scala/org/nd4j/api/ops/BitFilterOps.scala
@@ -1,0 +1,40 @@
+package org.nd4j.api.ops
+
+import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.api.ops.{Op, BaseScalarOp}
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.api.Implicits._
+
+object BitFilterOps {
+  def apply(x:INDArray,f:Double=>Boolean):BitFilterOps = new BitFilterOps(x,x.length(),f)
+}
+class BitFilterOps(_x:INDArray,len:Int,f:Double => Boolean) extends BaseScalarOp(_x,null:INDArray,_x,len,0){
+  def this(){
+    this(0.toScalar,0,null)
+  }
+
+  x = _x
+  override def name(): String = "bitfilter_scalar"
+
+  override def opForDimension(index: Int, dimension: Int): Op = BitFilterOps(x.tensorAlongDimension(index,dimension),f)
+
+  override def opForDimension(index: Int, dimension: Int*): Op = BitFilterOps(x.tensorAlongDimension(index,dimension:_*),f)
+
+  override def op(origin: IComplexNumber, other: Double): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: Float): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: IComplexNumber): IComplexNumber = op(origin)
+
+  override def op(origin: Float, other: Float): Float = op(origin)
+
+  override def op(origin: Double, other: Double): Double = op(origin)
+
+  override def op(origin: Double): Double = if(f(origin)) 1 else 0
+
+  override def op(origin: Float): Float = if(f(origin)) 1 else 0
+
+  override def op(origin: IComplexNumber): IComplexNumber = if(f(origin.absoluteValue().doubleValue())) Nd4j.createComplexNumber(1,0) else Nd4j.createComplexNumber(0, 0)
+}
+

--- a/src/main/scala/org/nd4j/api/ops/FilterOps.scala
+++ b/src/main/scala/org/nd4j/api/ops/FilterOps.scala
@@ -1,0 +1,39 @@
+package org.nd4j.api.ops
+
+import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.api.ops.{BaseScalarOp, Op}
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.api.Implicits._
+
+object FilterOps{
+  def apply(x:INDArray,f:Double=>Boolean):FilterOps = new FilterOps(x,x.length(),f)
+}
+class FilterOps(_x:INDArray,len:Int,f:Double => Boolean) extends BaseScalarOp(_x,null:INDArray,_x,len,0){
+  def this(){
+    this(0.toScalar,0,null)
+  }
+
+  x = _x
+  override def name(): String = "filter_scalar"
+
+  override def opForDimension(index: Int, dimension: Int): Op = FilterOps(x.tensorAlongDimension(index,dimension),f)
+
+  override def opForDimension(index: Int, dimension: Int*): Op = FilterOps(x.tensorAlongDimension(index,dimension:_*),f)
+
+  override def op(origin: IComplexNumber, other: Double): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: Float): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: IComplexNumber): IComplexNumber = op(origin)
+
+  override def op(origin: Float, other: Float): Float = op(origin)
+
+  override def op(origin: Double, other: Double): Double = op(origin)
+
+  override def op(origin: Double): Double = if(f(origin)) origin else 0
+
+  override def op(origin: Float): Float = if(f(origin)) origin else 0
+
+  override def op(origin: IComplexNumber): IComplexNumber = if(f(origin.absoluteValue().doubleValue())) origin else Nd4j.createComplexNumber(0, 0)
+}

--- a/src/main/scala/org/nd4j/api/ops/MapOps.scala
+++ b/src/main/scala/org/nd4j/api/ops/MapOps.scala
@@ -1,0 +1,38 @@
+package org.nd4j.api.ops
+
+import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.api.ops.{BaseScalarOp, BaseOp, Op}
+import org.nd4j.api.Implicits._
+
+object MapOps{
+  def apply(x:INDArray,f:Double=>Double,g:IComplexNumber =>IComplexNumber):MapOps = new MapOps(x,f,g)
+}
+class MapOps(_x:INDArray,f:Double => Double, g:IComplexNumber => IComplexNumber) extends BaseScalarOp(_x,null,_x,_x.length(),0){
+  x = _x
+  def this(){
+    this(0.toScalar,null,null)
+  }
+
+  override def name(): String = "map_scalar"
+
+  override def opForDimension(index: Int, dimension: Int): Op = MapOps(x.tensorAlongDimension(index,dimension),f,g)
+
+  override def opForDimension(index: Int, dimension: Int*): Op = MapOps(x.tensorAlongDimension(index,dimension:_*),f,g)
+
+  override def op(origin: IComplexNumber, other: Double): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: Float): IComplexNumber = op(origin)
+
+  override def op(origin: IComplexNumber, other: IComplexNumber): IComplexNumber = op(origin)
+
+  override def op(origin: Float, other: Float): Float = op(origin)
+
+  override def op(origin: Double, other: Double): Double = op(origin)
+
+  override def op(origin: Double): Double = f(origin)
+
+  override def op(origin: Float): Float = f(origin).toFloat
+
+  override def op(origin: IComplexNumber): IComplexNumber = g(origin)
+}

--- a/src/test/scala/org/nd4j/api/NDArrayCollectionAPITest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayCollectionAPITest.scala
@@ -1,0 +1,59 @@
+package org.nd4j.api
+
+import org.nd4j.api.Implicits._
+import org.nd4j.linalg.factory.Nd4j
+import org.scalatest.FlatSpec
+
+class NDArrayCollectionAPITest extends FlatSpec {
+  "CollectionLikeNDArray" should "provides filter API" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    val filtered = ndArray.filter(_ > 3)
+
+    assert(filtered ==
+      Array(
+        Array(0, 0, 0),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray)
+  }
+  it should "provides filter bitmask API" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    val filterMasked = ndArray.filterBit(_ % 2 == 0)
+
+    assert(filterMasked ==
+      Array(
+        Array(0, 1, 0),
+        Array(1, 0, 1),
+        Array(0, 1, 0)
+      ).toNDArray)
+  }
+  it should "provides map API" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    val mapped = ndArray.map(_ * 2 + 1)
+
+    assert(mapped ==
+      Array(
+        Array(3, 5, 7),
+        Array(9, 11, 13),
+        Array(15, 17, 19)
+      ).toNDArray)
+  }
+}


### PR DESCRIPTION
this adds the following higher order functions with leveraging OpExecutioner

```scala
val ndArray =
      Array(
        Array(1, 2, 3),
        Array(4, 5, 6),
        Array(7, 8, 9)
      ).toNDArray

ndArray.filter(_ > 3)

assert(filtered ==
      Array(
        Array(0, 0, 0),
        Array(4, 5, 6),
        Array(7, 8, 9)
      ).toNDArray)

val filterMasked = ndArray.filterBit(_ % 2 == 0)

assert(filterMasked ==
      Array(
        Array(0, 1, 0),
        Array(1, 0, 1),
        Array(0, 1, 0)
      ).toNDArray)

val mapped = ndArray.map(_ * 2 + 1)

assert(mapped ==
      Array(
        Array(3, 5, 7),
        Array(9, 11, 13),
        Array(15, 17, 19)
      ).toNDArray)
```