### PR TITLE
fix #25 / refine RichNDArray operations

### DIFF
--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -1,13 +1,13 @@
 package org.nd4j.api
 
+import org.nd4j.linalg.api.complex.{IComplexNDArray, IComplexNumber}
 import org.nd4j.linalg.api.ndarray.INDArray
-import org.nd4j.linalg.factory.{NDArrayFactory, Nd4j}
+import org.nd4j.linalg.factory.Nd4j
 
 import _root_.scala.util.control.Breaks._
 
-object Implicits {
-
-  implicit class RichINDArray(val underlying: INDArray) extends SliceableNDArray with OperatableNDArray with CollectionLikeNDArray{
+object Implicits extends LowPriorityImplicits{
+  implicit class RichINDArray[A <: INDArray](val underlying: A) extends SliceableNDArray with OperatableNDArray[A] with CollectionLikeNDArray {
     def forall(f: Double => Boolean): Boolean = {
       var result = true
       val lv = underlying.linearView()
@@ -87,21 +87,27 @@ object Implicits {
   implicit class floatMtrix2INDArray(val underlying: Seq[Seq[Float]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying.map(_.toArray).toArray)
   }
+
   implicit class floatArrayMtrix2INDArray(val underlying: Array[Array[Float]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying)
   }
+
   implicit class doubleMtrix2INDArray(val underlying: Seq[Seq[Double]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying.map(_.toArray).toArray)
   }
+
   implicit class doubleArrayMtrix2INDArray(val underlying: Array[Array[Double]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying)
   }
+
   implicit class intMtrix2INDArray(val underlying: Seq[Seq[Int]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying.map(_.map(_.toFloat).toArray).toArray)
   }
+
   implicit class intArrayMtrix2INDArray(val underlying: Array[Array[Int]]) extends AnyVal {
     def toNDArray: INDArray = Nd4j.create(underlying.map(_.map(_.toFloat)))
   }
+
   implicit class num2Scalar[T](val underlying: T)(implicit ev: Numeric[T]) {
     def toScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
@@ -156,7 +162,7 @@ private[api] case class DRange(startR: Int, endR: Int, isInclusive: Boolean, ste
     val endInclusive = if (endR >= 0) endR + diff else max + endR + diff
     (start, endInclusive)
   }
-  lazy val length = (end  - start) / step + 1
+  lazy val length = (end - start) / step + 1
 
   def toList: List[Int] = List.iterate(start, length)(_ + step)
 
@@ -165,5 +171,6 @@ private[api] case class DRange(startR: Int, endR: Int, isInclusive: Boolean, ste
 
 private[api] object DRange extends {
   def from(r: Range, max: => Int): DRange = DRange(r.start, r.end, r.isInclusive, r.step, max)
+
   def apply(startR: Int, endR: Int, step: Int): DRange = DRange(startR, endR, false, step, Int.MinValue)
 }

--- a/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
+++ b/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
@@ -1,0 +1,112 @@
+package org.nd4j.api
+
+import org.nd4j.linalg.api.complex.{IComplexNumber, IComplexNDArray}
+import org.nd4j.linalg.api.ndarray.INDArray
+
+
+object Evidences {
+  implicit val double = DoubleNDArrayEvidence
+  implicit val float = DoubleNDArrayEvidence
+  implicit val complex = ComplexNDArrayEvidence
+}
+object NDArrayEvidence{
+  implicit val doubleNDArrayEvidence = DoubleNDArrayEvidence
+
+  implicit val complexNDArrayEvidence = ComplexNDArrayEvidence
+}
+
+trait NDArrayEvidence[A]{
+  type T
+
+  def sum(ndarray: A): T
+
+  def mean(ndarray: A): T
+
+  def normMax(ndarray: A): T
+
+  def norm1(ndarray: A): T
+
+  def norm2(ndarray: A): T
+
+  def max(ndarray: A): T
+
+  def min(ndarray: A): T
+
+  def standardDeviation(ndarray: A): T
+
+  def product(ndarray: A): T
+
+  def variance(ndarray: A): T
+}
+
+case object DoubleNDArrayEvidence extends NDArrayEvidence[INDArray] {
+  override type T = Double
+
+  override def sum(ndarray: INDArray): T = ndarray.sumNumber().doubleValue()
+
+  override def mean(ndarray: INDArray): T = ndarray.meanNumber().doubleValue()
+
+  override def variance(ndarray: INDArray): T = ndarray.varNumber().doubleValue()
+
+  override def norm2(ndarray: INDArray): T = ndarray.norm2Number().doubleValue()
+
+  override def max(ndarray: INDArray): T = ndarray.maxNumber().doubleValue()
+
+  override def product(ndarray: INDArray): T = ndarray.prodNumber().doubleValue()
+
+  override def standardDeviation(ndarray: INDArray): T = ndarray.stdNumber().doubleValue()
+
+  override def normMax(ndarray: INDArray): T = ndarray.normmaxNumber().doubleValue()
+
+  override def min(ndarray: INDArray): T = ndarray.minNumber().doubleValue()
+
+  override def norm1(ndarray: INDArray): T = ndarray.norm1Number().doubleValue()
+}
+
+case object FloatNDArrayEvidence extends NDArrayEvidence[INDArray] {
+  override type T = Float
+
+  override def sum(ndarray: INDArray): T = ndarray.sumNumber().floatValue()
+
+  override def mean(ndarray: INDArray): T = ndarray.meanNumber().floatValue()
+
+  override def variance(ndarray: INDArray): T = ndarray.varNumber().floatValue()
+
+  override def norm2(ndarray: INDArray): T = ndarray.norm2Number().floatValue()
+
+  override def max(ndarray: INDArray): T = ndarray.maxNumber().floatValue()
+
+  override def product(ndarray: INDArray): T = ndarray.prodNumber().floatValue()
+
+  override def standardDeviation(ndarray: INDArray): T = ndarray.stdNumber().floatValue()
+
+  override def normMax(ndarray: INDArray): T = ndarray.normmaxNumber().floatValue()
+
+  override def min(ndarray: INDArray): T = ndarray.minNumber().floatValue()
+
+  override def norm1(ndarray: INDArray): T = ndarray.norm1Number().floatValue()
+}
+
+case object ComplexNDArrayEvidence extends NDArrayEvidence[IComplexNDArray] {
+  override type T = IComplexNumber
+
+  override def sum(ndarray: IComplexNDArray): T = ndarray.sumComplex()
+
+  override def mean(ndarray: IComplexNDArray): T = ndarray.meanComplex()
+
+  override def variance(ndarray: IComplexNDArray): T = ndarray.varComplex()
+
+  override def norm2(ndarray: IComplexNDArray): T = ndarray.norm2Complex()
+
+  override def max(ndarray: IComplexNDArray): T = ndarray.maxComplex()
+
+  override def product(ndarray: IComplexNDArray): T = ndarray.prodComplex()
+
+  override def standardDeviation(ndarray: IComplexNDArray): T = ndarray.stdComplex()
+
+  override def normMax(ndarray: IComplexNDArray): T = ndarray.normmaxComplex()
+
+  override def min(ndarray: IComplexNDArray): T = ndarray.minComplex()
+
+  override def norm1(ndarray: IComplexNDArray): T = ndarray.norm1Complex()
+}

--- a/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
+++ b/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
@@ -2,111 +2,284 @@ package org.nd4j.api
 
 import org.nd4j.linalg.api.complex.{IComplexNumber, IComplexNDArray}
 import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.indexing.NDArrayIndex
 
 
 object Evidences {
   implicit val double = DoubleNDArrayEvidence
-  implicit val float = DoubleNDArrayEvidence
+  implicit val float = FloatNDArrayEvidence
   implicit val complex = ComplexNDArrayEvidence
 }
-object NDArrayEvidence{
+
+object NDArrayEvidence {
   implicit val doubleNDArrayEvidence = DoubleNDArrayEvidence
 
   implicit val complexNDArrayEvidence = ComplexNDArrayEvidence
 }
 
-trait NDArrayEvidence[A]{
-  type T
+trait NDArrayEvidence[A] {
+  type Value
+  type NDArray = A
 
-  def sum(ndarray: A): T
+  def sum(ndarray: A): Value
 
-  def mean(ndarray: A): T
+  def mean(ndarray: A): Value
 
-  def normMax(ndarray: A): T
+  def normMax(ndarray: A): Value
 
-  def norm1(ndarray: A): T
+  def norm1(ndarray: A): Value
 
-  def norm2(ndarray: A): T
+  def norm2(ndarray: A): Value
 
-  def max(ndarray: A): T
+  def max(ndarray: A): Value
 
-  def min(ndarray: A): T
+  def min(ndarray: A): Value
 
-  def standardDeviation(ndarray: A): T
+  def standardDeviation(ndarray: A): Value
 
-  def product(ndarray: A): T
+  def product(ndarray: A): Value
 
-  def variance(ndarray: A): T
+  def variance(ndarray: A): Value
+
+  def add(a: A, that: INDArray): A
+
+  def sub(a: A, that: INDArray): A
+
+  def mul(a: A, that: INDArray): A
+
+  def mmul(a: A, that: INDArray): A
+
+  def div(a: A, that: INDArray): A
+
+  def rdiv(a: A, that: INDArray): A
+
+  def addi(a: A, that: INDArray): A
+
+  def subi(a: A, that: INDArray): A
+
+  def muli(a: A, that: INDArray): A
+
+  def mmuli(a: A, that: INDArray): A
+
+  def divi(a: A, that: INDArray): A
+
+  def rdivi(a: A, that: INDArray): A
+
+  def add(a: A, that: Number): A
+
+  def sub(a: A, that: Number): A
+
+  def mul(a: A, that: Number): A
+
+  def div(a: A, that: Number): A
+
+  def rdiv(a: A, that: Number): A
+
+  def addi(a: A, that: Number): A
+
+  def subi(a: A, that: Number): A
+
+  def muli(a: A, that: Number): A
+
+  def divi(a: A, that: Number): A
+
+  def rdivi(a: A, that: Number): A
+
+  def put(a: A, i: Int, element: INDArray): A
+
+  def put(a: A, i: Array[Int], element: INDArray): A
+
+  def get(a: A, i: Int): Value
+
+  def get(a: A, i: Int, j: Int): Value
+
+  def get(a: A, i: Int*): Value
 }
 
-case object DoubleNDArrayEvidence extends NDArrayEvidence[INDArray] {
-  override type T = Double
+trait RealNDArrayEvidence extends NDArrayEvidence[INDArray] {
+  override def add(a: INDArray, that: INDArray): INDArray = a.add(that)
 
-  override def sum(ndarray: INDArray): T = ndarray.sumNumber().doubleValue()
+  override def div(a: INDArray, that: INDArray): INDArray = a.div(that)
 
-  override def mean(ndarray: INDArray): T = ndarray.meanNumber().doubleValue()
+  override def mul(a: INDArray, that: INDArray): INDArray = a.mul(that)
 
-  override def variance(ndarray: INDArray): T = ndarray.varNumber().doubleValue()
+  override def rdiv(a: INDArray, that: INDArray): INDArray = a.rdiv(that)
 
-  override def norm2(ndarray: INDArray): T = ndarray.norm2Number().doubleValue()
+  override def sub(a: INDArray, that: INDArray): INDArray = a.sub(that)
 
-  override def max(ndarray: INDArray): T = ndarray.maxNumber().doubleValue()
+  override def mmul(a: INDArray, that: INDArray): INDArray = a.mmul(that)
 
-  override def product(ndarray: INDArray): T = ndarray.prodNumber().doubleValue()
+  override def addi(a: INDArray, that: INDArray): INDArray = a.addi(that)
 
-  override def standardDeviation(ndarray: INDArray): T = ndarray.stdNumber().doubleValue()
+  override def subi(a: INDArray, that: INDArray): INDArray = a.subi(that)
 
-  override def normMax(ndarray: INDArray): T = ndarray.normmaxNumber().doubleValue()
+  override def muli(a: INDArray, that: INDArray): INDArray = a.muli(that)
 
-  override def min(ndarray: INDArray): T = ndarray.minNumber().doubleValue()
+  override def mmuli(a: INDArray, that: INDArray): INDArray = a.mmuli(that)
 
-  override def norm1(ndarray: INDArray): T = ndarray.norm1Number().doubleValue()
+  override def divi(a: INDArray, that: INDArray): INDArray = a.divi(that)
+
+  override def rdivi(a: INDArray, that: INDArray): INDArray = a.rdivi(that)
+
+  override def add(a: INDArray, that: Number): INDArray = a.add(that)
+
+  override def sub(a: INDArray, that: Number): INDArray = a.sub(that)
+
+  override def mul(a: INDArray, that: Number): INDArray = a.mul(that)
+
+  override def div(a: INDArray, that: Number): INDArray = a.div(that)
+
+  override def rdiv(a: INDArray, that: Number): INDArray = a.rdiv(that)
+
+  override def addi(a: INDArray, that: Number): INDArray = a.addi(that)
+
+  override def subi(a: INDArray, that: Number): INDArray = a.subi(that)
+
+  override def muli(a: INDArray, that: Number): INDArray = a.muli(that)
+
+  override def divi(a: INDArray, that: Number): INDArray = a.divi(that)
+
+  override def rdivi(a: INDArray, that: Number): INDArray = a.rdivi(that)
+
+  override def put(a: INDArray, i:Array[Int], element: INDArray): INDArray = a.put(i,element)
+
+  override def put(a: INDArray, i: Int, element: INDArray): INDArray = a.put(i,element)
 }
 
-case object FloatNDArrayEvidence extends NDArrayEvidence[INDArray] {
-  override type T = Float
+case object DoubleNDArrayEvidence extends RealNDArrayEvidence {
+  override type Value = Double
 
-  override def sum(ndarray: INDArray): T = ndarray.sumNumber().floatValue()
+  override def sum(ndarray: INDArray): Value = ndarray.sumNumber().doubleValue()
 
-  override def mean(ndarray: INDArray): T = ndarray.meanNumber().floatValue()
+  override def mean(ndarray: INDArray): Value = ndarray.meanNumber().doubleValue()
 
-  override def variance(ndarray: INDArray): T = ndarray.varNumber().floatValue()
+  override def variance(ndarray: INDArray): Value = ndarray.varNumber().doubleValue()
 
-  override def norm2(ndarray: INDArray): T = ndarray.norm2Number().floatValue()
+  override def norm2(ndarray: INDArray): Value = ndarray.norm2Number().doubleValue()
 
-  override def max(ndarray: INDArray): T = ndarray.maxNumber().floatValue()
+  override def max(ndarray: INDArray): Value = ndarray.maxNumber().doubleValue()
 
-  override def product(ndarray: INDArray): T = ndarray.prodNumber().floatValue()
+  override def product(ndarray: INDArray): Value = ndarray.prodNumber().doubleValue()
 
-  override def standardDeviation(ndarray: INDArray): T = ndarray.stdNumber().floatValue()
+  override def standardDeviation(ndarray: INDArray): Value = ndarray.stdNumber().doubleValue()
 
-  override def normMax(ndarray: INDArray): T = ndarray.normmaxNumber().floatValue()
+  override def normMax(ndarray: INDArray): Value = ndarray.normmaxNumber().doubleValue()
 
-  override def min(ndarray: INDArray): T = ndarray.minNumber().floatValue()
+  override def min(ndarray: INDArray): Value = ndarray.minNumber().doubleValue()
 
-  override def norm1(ndarray: INDArray): T = ndarray.norm1Number().floatValue()
+  override def norm1(ndarray: INDArray): Value = ndarray.norm1Number().doubleValue()
+
+  override def get(a: INDArray, i: Int): Value = a.getDouble(i)
+
+  override def get(a: INDArray, i: Int, j: Int): Value = a.getDouble(i,j)
+
+  override def get(a: INDArray, i: Int*): Value = a.getDouble(i:_*)
+}
+
+case object FloatNDArrayEvidence extends RealNDArrayEvidence {
+  override type Value = Float
+
+  override def sum(ndarray: INDArray): Value = ndarray.sumNumber().floatValue()
+
+  override def mean(ndarray: INDArray): Value = ndarray.meanNumber().floatValue()
+
+  override def variance(ndarray: INDArray): Value = ndarray.varNumber().floatValue()
+
+  override def norm2(ndarray: INDArray): Value = ndarray.norm2Number().floatValue()
+
+  override def max(ndarray: INDArray): Value = ndarray.maxNumber().floatValue()
+
+  override def product(ndarray: INDArray): Value = ndarray.prodNumber().floatValue()
+
+  override def standardDeviation(ndarray: INDArray): Value = ndarray.stdNumber().floatValue()
+
+  override def normMax(ndarray: INDArray): Value = ndarray.normmaxNumber().floatValue()
+
+  override def min(ndarray: INDArray): Value = ndarray.minNumber().floatValue()
+
+  override def norm1(ndarray: INDArray): Value = ndarray.norm1Number().floatValue()
+
+  override def get(a: INDArray, i: Int): Value = a.getFloat(i)
+
+  override def get(a: INDArray, i: Int, j: Int): Value = a.getFloat(i,j)
+
+  override def get(a: INDArray, i: Int*): Value = a.getFloat(i.toArray)
 }
 
 case object ComplexNDArrayEvidence extends NDArrayEvidence[IComplexNDArray] {
-  override type T = IComplexNumber
+  override type Value = IComplexNumber
 
-  override def sum(ndarray: IComplexNDArray): T = ndarray.sumComplex()
+  override def sum(ndarray: IComplexNDArray): Value = ndarray.sumComplex()
 
-  override def mean(ndarray: IComplexNDArray): T = ndarray.meanComplex()
+  override def mean(ndarray: IComplexNDArray): Value = ndarray.meanComplex()
 
-  override def variance(ndarray: IComplexNDArray): T = ndarray.varComplex()
+  override def variance(ndarray: IComplexNDArray): Value = ndarray.varComplex()
 
-  override def norm2(ndarray: IComplexNDArray): T = ndarray.norm2Complex()
+  override def norm2(ndarray: IComplexNDArray): Value = ndarray.norm2Complex()
 
-  override def max(ndarray: IComplexNDArray): T = ndarray.maxComplex()
+  override def max(ndarray: IComplexNDArray): Value = ndarray.maxComplex()
 
-  override def product(ndarray: IComplexNDArray): T = ndarray.prodComplex()
+  override def product(ndarray: IComplexNDArray): Value = ndarray.prodComplex()
 
-  override def standardDeviation(ndarray: IComplexNDArray): T = ndarray.stdComplex()
+  override def standardDeviation(ndarray: IComplexNDArray): Value = ndarray.stdComplex()
 
-  override def normMax(ndarray: IComplexNDArray): T = ndarray.normmaxComplex()
+  override def normMax(ndarray: IComplexNDArray): Value = ndarray.normmaxComplex()
 
-  override def min(ndarray: IComplexNDArray): T = ndarray.minComplex()
+  override def min(ndarray: IComplexNDArray): Value = ndarray.minComplex()
 
-  override def norm1(ndarray: IComplexNDArray): T = ndarray.norm1Complex()
+  override def norm1(ndarray: IComplexNDArray): Value = ndarray.norm1Complex()
+
+  override def add(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.add(that)
+
+  override def div(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.div(that)
+
+  override def mul(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.mul(that)
+
+  override def rdiv(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.rdiv(that)
+
+  override def sub(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.sub(that)
+
+  override def mmul(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.mmul(that)
+
+  override def addi(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.addi(that)
+
+  override def div(a: IComplexNDArray, that: Number): IComplexNDArray = a.div(that)
+
+  override def addi(a: IComplexNDArray, that: Number): IComplexNDArray = a.addi(that)
+
+  override def mul(a: IComplexNDArray, that: Number): IComplexNDArray = a.mul(that)
+
+  override def rdivi(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.rdivi(that)
+
+  override def rdivi(a: IComplexNDArray, that: Number): IComplexNDArray = a.rdivi(that)
+
+  override def divi(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.divi(that)
+
+  override def divi(a: IComplexNDArray, that: Number): IComplexNDArray = a.divi(that)
+
+  override def rdiv(a: IComplexNDArray, that: Number): IComplexNDArray = a.rdiv(that)
+
+  override def muli(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.muli(that)
+
+  override def muli(a: IComplexNDArray, that: Number): IComplexNDArray = a.muli(that)
+
+  override def sub(a: IComplexNDArray, that: Number): IComplexNDArray = a.sub(that)
+
+  override def subi(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.subi(that)
+
+  override def subi(a: IComplexNDArray, that: Number): IComplexNDArray = a.subi(that)
+
+  override def add(a: IComplexNDArray, that: Number): IComplexNDArray = a.add(that)
+
+  override def mmuli(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.mmuli(that)
+
+  override def get(a: IComplexNDArray, i: Int): Value = a.getComplex(i)
+
+  override def get(a: IComplexNDArray, i: Int, j: Int): Value = a.getComplex(i,j)
+
+  override def get(a: IComplexNDArray, i: Int*): Value = a.getComplex(i:_*)
+
+  override def put(a: IComplexNDArray, i: Int, element: INDArray): IComplexNDArray = a.put(i,element)
+
+  override def put(a: IComplexNDArray, i: Array[Int], element: INDArray): IComplexNDArray = a.put(i,element)
 }

--- a/src/main/scala/org/nd4j/api/OperatableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/OperatableNDArray.scala
@@ -27,8 +27,8 @@ import org.nd4j.linalg.indexing.NDArrayIndex
 /**
  * Scala DSL for arrays
  */
-trait OperatableNDArray{
-  val underlying:INDArray
+trait OperatableNDArray[A <: INDArray] {
+  val underlying: A
 
   // --- INDArray operators
   def +(that: INDArray): INDArray = underlying.add(that)
@@ -135,6 +135,26 @@ trait OperatableNDArray{
   def ===(other: Number): INDArray = underlying.eq(other)
 
   def ===(other: INDArray): INDArray = underlying.eq(other)
+
+  def sumT(implicit ev: NDArrayEvidence[A]): ev.T = ev.sum(underlying)
+
+  def meanT(implicit ev: NDArrayEvidence[A]): ev.T = ev.sum(underlying)
+
+  def normMaxT(implicit ev: NDArrayEvidence[A]): ev.T = ev.normMax(underlying)
+
+  def norm1T(implicit ev: NDArrayEvidence[A]): ev.T = ev.norm1(underlying)
+
+  def norm2T(implicit ev: NDArrayEvidence[A]): ev.T = ev.norm2(underlying)
+
+  def maxT(implicit ev: NDArrayEvidence[A]): ev.T = ev.max(underlying)
+
+  def minT(implicit ev: NDArrayEvidence[A]): ev.T = ev.min(underlying)
+
+  def stdT(implicit ev: NDArrayEvidence[A]): ev.T = ev.standardDeviation(underlying)
+
+  def prodT(implicit ev: NDArrayEvidence[A]): ev.T = ev.product(underlying)
+
+  def varT()(implicit ev: NDArrayEvidence[A]): ev.T = ev.variance(underlying)
 }
 
 // https://gist.github.com/teroxik/5349331

--- a/src/main/scala/org/nd4j/api/OperatableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/OperatableNDArray.scala
@@ -31,65 +31,65 @@ trait OperatableNDArray[A <: INDArray] {
   val underlying: A
 
   // --- INDArray operators
-  def +(that: INDArray): INDArray = underlying.add(that)
+  def +(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.add(underlying,that)
 
-  def -(that: INDArray): INDArray = underlying.sub(that)
+  def -(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.sub(underlying,that)
 
   /** element-by-element multiplication */
-  def *(that: INDArray): INDArray = underlying.mul(that)
+  def *(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mul(underlying,that)
 
   /** matrix multiplication */
-  def **(that: INDArray): INDArray = underlying.mmul(that)
+  def **(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmul(underlying,that)
 
   /** matrix multiplication using Numpy syntax for arrays */
-  def dot(that: INDArray): INDArray = underlying.mmul(that)
+  def dot(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmul(underlying,that)
 
-  def /(that: INDArray): INDArray = underlying.div(that)
+  def /(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray  = ev.div(underlying,that)
 
   /** right division ... is this the correct symbol? */
-  def \(that: INDArray): INDArray = underlying.rdiv(that)
+  def \(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray  = ev.rdiv(underlying,that)
 
   // --- In-place INDArray opertors
   /** In-place addition */
-  def +=(that: INDArray): INDArray = underlying.addi(that)
+  def +=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.addi(underlying,that)
 
   /** In-place subtraction */
-  def -=(that: INDArray): INDArray = underlying.subi(that)
+  def -=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.subi(underlying,that)
 
   /** In-placeelement-by-element multiplication */
-  def *=(that: INDArray): INDArray = underlying.muli(that)
+  def *=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.muli(underlying,that)
 
   /** In-place matrix multiplication */
-  def **=(that: INDArray): INDArray = underlying.mmuli(that)
+  def **=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmuli(underlying,that)
 
   /** In-place division */
-  def /=(that: INDArray): INDArray = underlying.divi(that)
+  def /=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.divi(underlying,that)
 
   /** In-place right division */
-  def \=(that: INDArray): INDArray = underlying.rdivi(that)
+  def \=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdivi(underlying,that)
 
   // --- Number operators
-  def +(that: Number): INDArray = underlying.add(that)
+  def +(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.add(underlying,that)
 
-  def -(that: Number): INDArray = underlying.sub(that)
+  def -(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.sub(underlying,that)
 
-  def *(that: Number): INDArray = underlying.mul(that)
+  def *(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mul(underlying,that)
 
-  def /(that: Number): INDArray = underlying.div(that)
+  def /(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.div(underlying,that)
 
-  def \(that: Number): INDArray = underlying.rdiv(that)
+  def \(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdiv(underlying,that)
 
   // --- In-place Number operators
-  def +=(that: Number): INDArray = underlying.addi(that)
+  def +=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.addi(underlying,that)
 
-  def -=(that: Number): INDArray = underlying.subi(that)
+  def -=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.subi(underlying,that)
 
-  def *=(that: Number): INDArray = underlying.muli(that)
+  def *=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.muli(underlying,that)
 
-  def /=(that: Number): INDArray = underlying.divi(that)
+  def /=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.divi(underlying,that)
 
   /** right division ... is this the correct symbol? */
-  def \=(that: Number): INDArray = underlying.rdivi(that)
+  def \=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdivi(underlying,that)
 
   // --- Complex operators
   def +(that: IComplexNumber): IComplexNDArray = underlying.add(that)
@@ -100,19 +100,19 @@ trait OperatableNDArray[A <: INDArray] {
 
   def /(that: IComplexNumber): IComplexNDArray = underlying.div(that)
 
-  def get(i: Int): Double = underlying.getDouble(i)
+  def get(i: Int)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,i)
 
-  def get(i: Int, j: Int): Double = underlying.getDouble(i, j)
+  def get(i: Int, j: Int)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,i, j)
 
-  def get(indices: Int*): Double = underlying.getDouble(indices: _*)
+  def get(indices: Int*)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,indices: _*)
 
-  def get(indices: Array[Int]): Double = underlying.getDouble(indices: _*)
+  def get(indices: Array[Int])(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,indices: _*)
 
-  def update(i: Int, element: INDArray): INDArray = underlying.put(i, element)
+  def update(i: Int, element: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.put(underlying,i, element)
+
+  def update(indices: Array[Int], element: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.put(underlying, indices, element)
 
   def update(indices: Array[NDArrayIndex], element: INDArray): INDArray = underlying.put(indices, element)
-
-  def update(indices: Array[Int], element: INDArray): INDArray = underlying.put(indices, element)
 
   def update(i: Int, j: Int, element: INDArray): INDArray = underlying.put(i, j, element)
 
@@ -136,45 +136,23 @@ trait OperatableNDArray[A <: INDArray] {
 
   def ===(other: INDArray): INDArray = underlying.eq(other)
 
-  def sumT(implicit ev: NDArrayEvidence[A]): ev.T = ev.sum(underlying)
+  def sumT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.sum(underlying)
 
-  def meanT(implicit ev: NDArrayEvidence[A]): ev.T = ev.sum(underlying)
+  def meanT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.sum(underlying)
 
-  def normMaxT(implicit ev: NDArrayEvidence[A]): ev.T = ev.normMax(underlying)
+  def normMaxT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.normMax(underlying)
 
-  def norm1T(implicit ev: NDArrayEvidence[A]): ev.T = ev.norm1(underlying)
+  def norm1T(implicit ev: NDArrayEvidence[A]): ev.Value = ev.norm1(underlying)
 
-  def norm2T(implicit ev: NDArrayEvidence[A]): ev.T = ev.norm2(underlying)
+  def norm2T(implicit ev: NDArrayEvidence[A]): ev.Value = ev.norm2(underlying)
 
-  def maxT(implicit ev: NDArrayEvidence[A]): ev.T = ev.max(underlying)
+  def maxT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.max(underlying)
 
-  def minT(implicit ev: NDArrayEvidence[A]): ev.T = ev.min(underlying)
+  def minT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.min(underlying)
 
-  def stdT(implicit ev: NDArrayEvidence[A]): ev.T = ev.standardDeviation(underlying)
+  def stdT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.standardDeviation(underlying)
 
-  def prodT(implicit ev: NDArrayEvidence[A]): ev.T = ev.product(underlying)
+  def prodT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.product(underlying)
 
-  def varT()(implicit ev: NDArrayEvidence[A]): ev.T = ev.variance(underlying)
-}
-
-// https://gist.github.com/teroxik/5349331
-class RichComplexNDArray(a: IComplexNDArray) {
-
-  def +(that: INDArray): IComplexNDArray = a.add(that)
-
-  def -(that: INDArray): IComplexNDArray = a.sub(that)
-
-  /** element-by-element multiplication */
-  def *(that: INDArray): IComplexNDArray = a.mul(that)
-
-  /** matrix multiplication */
-  def **(that: INDArray): IComplexNDArray = a.mmul(that)
-
-  /** matrix multiplication using Numpy syntax for arrays */
-  def dot(that: INDArray): IComplexNDArray = a.mmul(that)
-
-  def /(that: INDArray): IComplexNDArray = a.div(that)
-
-  /** right division ... is this the correct symbol? */
-  def \(that: INDArray): IComplexNDArray = a.rdiv(that)
+  def varT()(implicit ev: NDArrayEvidence[A]): ev.Value = ev.variance(underlying)
 }

--- a/src/test/scala/org/nd4j/api/NDArrayCollectionAPITest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayCollectionAPITest.scala
@@ -1,7 +1,6 @@
 package org.nd4j.api
 
 import org.nd4j.api.Implicits._
-import org.nd4j.linalg.factory.Nd4j
 import org.scalatest.FlatSpec
 
 class NDArrayCollectionAPITest extends FlatSpec {

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -1,11 +1,10 @@
 package org.nd4j.api
 
-import org.scalatest.FlatSpec
-
 import org.nd4j.api.Implicits._
 import org.nd4j.linalg.factory.Nd4j
+import org.scalatest.FlatSpec
 
-class NDArrayExtractionTest extends FlatSpec {
+class NDArrayExtractionTest extends FlatSpec{
   "org.nd4j.api.Implicits.RichNDArray" should "provides forall checker" in {
     val ndArray =
       Array(

--- a/src/test/scala/org/nd4j/api/linalg/OperatableNDArrayTest.scala
+++ b/src/test/scala/org/nd4j/api/linalg/OperatableNDArrayTest.scala
@@ -20,13 +20,16 @@
 package org.nd4j.api.linalg
 
 import org.junit.runner.RunWith
+import org.nd4j.api.Implicits._
+import org.nd4j.api.{FloatNDArrayEvidence, NDArrayEvidence}
+import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.ndarray.INDArray
 import org.nd4j.linalg.factory.Nd4j
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
-import org.nd4j.api.Implicits._
 
 @RunWith(classOf[JUnitRunner])
-class RichNDArraySpec extends FlatSpec with Matchers {
+class OperatableNDArrayTest extends FlatSpec with Matchers {
   "RichNDArray" should "use the apply method to access values" in {
     // -- 2D array
     val nd2 = Nd4j.create(Array[Double](1, 2, 3, 4), Array(4, 1))
@@ -122,5 +125,32 @@ class RichNDArraySpec extends FlatSpec with Matchers {
     val b = -a
     b.get(0) should be(-1)
     b.get(1) should be(-3)
+  }
+
+  "Sum function" should "choose return value depending on INDArray type" in {
+    val ndArray =
+      Array(
+        Array(1, 2),
+        Array(4, 5)
+      ).toNDArray
+
+    //return sum of real NDArray in Double at default
+    val sumValue = ndArray.sumT
+    sumValue shouldBe a [java.lang.Double]
+
+    val complexNDArray = Nd4j.createComplex(ndArray)
+
+    //return sum of complex NDArray in IComplexNumber
+    val sumComplexValue = complexNDArray.sumT
+    sumComplexValue shouldBe a [IComplexNumber]
+
+    //switch return value with passing corresponding evidence explicitly
+    val sumValueInFloatExplicit = ndArray.sumT(FloatNDArrayEvidence)
+    sumValueInFloatExplicit shouldBe a [java.lang.Float]
+
+    //switch return value with declaring implicit value but explicit one would be more readable.
+    implicit val f:NDArrayEvidence[INDArray] = FloatNDArrayEvidence
+    val sumValueInFloatImplicit = ndArray.sumT
+    sumValueInFloatImplicit shouldBe a [java.lang.Float]
   }
 }

--- a/src/test/scala/org/nd4j/api/linalg/OperatableNDArrayTest.scala
+++ b/src/test/scala/org/nd4j/api/linalg/OperatableNDArrayTest.scala
@@ -22,7 +22,7 @@ package org.nd4j.api.linalg
 import org.junit.runner.RunWith
 import org.nd4j.api.Implicits._
 import org.nd4j.api.{FloatNDArrayEvidence, NDArrayEvidence}
-import org.nd4j.linalg.api.complex.IComplexNumber
+import org.nd4j.linalg.api.complex.{IComplexNDArray, IComplexNumber}
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.nd4j.linalg.factory.Nd4j
 import org.scalatest.junit.JUnitRunner
@@ -48,7 +48,7 @@ class OperatableNDArrayTest extends FlatSpec with Matchers {
     val nd1 = Nd4j.create(Array[Double](1, 2, 3), Array(3, 1))
     nd1.shape should equal(Array(3, 1))
     val nd1t = nd1.T
-    nd1t.shape should equal(Array(1,3))
+    nd1t.shape should equal(Array(1, 3))
   }
 
   it should "add correctly" in {
@@ -127,6 +127,23 @@ class OperatableNDArrayTest extends FlatSpec with Matchers {
     b.get(1) should be(-3)
   }
 
+  it should "workd with ComplexNDArray correctly" in {
+    val complexNDArray = Nd4j.createComplex(
+      Array(
+        Array(Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(1, 1)),
+        Array(Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(1, 1)))
+    )
+
+    val result = complexNDArray + 2
+    result shouldBe a[IComplexNDArray]
+
+    result shouldBe Nd4j.createComplex(
+      Array(
+        Array(Nd4j.createComplexNumber(3, 1), Nd4j.createComplexNumber(3, 1)),
+        Array(Nd4j.createComplexNumber(3, 1), Nd4j.createComplexNumber(3, 1)))
+    )
+  }
+
   "Sum function" should "choose return value depending on INDArray type" in {
     val ndArray =
       Array(
@@ -134,23 +151,25 @@ class OperatableNDArrayTest extends FlatSpec with Matchers {
         Array(4, 5)
       ).toNDArray
 
-    //return sum of real NDArray in Double at default
+    //return Double in real NDArray at default
+    ndArray.get(0) shouldBe a [java.lang.Double]
     val sumValue = ndArray.sumT
     sumValue shouldBe a [java.lang.Double]
 
     val complexNDArray = Nd4j.createComplex(ndArray)
 
-    //return sum of complex NDArray in IComplexNumber
+    //return ComplexNumber in ComplexNDArray in IComplexNumber
+    complexNDArray.get(0) shouldBe a [IComplexNumber]
     val sumComplexValue = complexNDArray.sumT
-    sumComplexValue shouldBe a [IComplexNumber]
+    sumComplexValue shouldBe a[IComplexNumber]
 
     //switch return value with passing corresponding evidence explicitly
     val sumValueInFloatExplicit = ndArray.sumT(FloatNDArrayEvidence)
-    sumValueInFloatExplicit shouldBe a [java.lang.Float]
+    sumValueInFloatExplicit shouldBe a[java.lang.Float]
 
     //switch return value with declaring implicit value but explicit one would be more readable.
-    implicit val f:NDArrayEvidence[INDArray] = FloatNDArrayEvidence
+    import org.nd4j.api.Evidences.float
     val sumValueInFloatImplicit = ndArray.sumT
-    sumValueInFloatImplicit shouldBe a [java.lang.Float]
+    sumValueInFloatImplicit shouldBe a[java.lang.Float]
   }
 }


### PR DESCRIPTION
This adds following syntax.
Of note, RichNDArray now return Double, IComplexNumber even in the same functions such as  `get` or  `sumT`, depending on NDArray type automatically (using Dependent Method Type).

If user imports or specify `Evidences.float`, `RichNDArray#get` or `sumT` can return Float value instead of Double.

```scala
    val ndArray =
      Array(
        Array(1, 2),
        Array(4, 5)
      ).toNDArray

    //return Double in real NDArray at default
    ndArray.get(0) shouldBe a [java.lang.Double]
    val sumValue = ndArray.sumT
    sumValue shouldBe a [java.lang.Double]

    val complexNDArray = Nd4j.createComplex(
      Array(
        Array(Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(1, 1)),
        Array(Nd4j.createComplexNumber(1, 1), Nd4j.createComplexNumber(1, 1)))
    )

    //return ComplexNumber in ComplexNDArray in IComplexNumber
    complexNDArray.get(0) shouldBe a [IComplexNumber]
    val sumComplexValue = complexNDArray.sumT
    sumComplexValue shouldBe a[IComplexNumber]

    //switch return value with passing corresponding evidence explicitly
    val sumValueInFloatExplicit = ndArray.sumT(FloatNDArrayEvidence)
    sumValueInFloatExplicit shouldBe a[java.lang.Float]

    //switch return value with declaring implicit value but explicit one would be more readable.
    import org.nd4j.api.Evidences.float
    val sumValueInFloatImplicit = ndArray.sumT
    sumValueInFloatImplicit shouldBe a[java.lang.Float]
```