### PR TITLE
fix RowVector slicing bug

### DIFF
--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -214,6 +214,8 @@ class NDArrayExtractionTest extends FlatSpec{
     val step = list(1 -> 7 by 2).linearView()
     assert(step.length() == 3)
     assert(step.getFloat(0) == 1)
+    assert(step(0) == 1.toScalar)
+    assert(step(0,0) == 1.toScalar)
     assert(step.getFloat(1) == 3)
     assert(step.getFloat(2) == 5)
 


### PR DESCRIPTION
This fixes the following bug in RowVector.

```scala
scala> val list = (0 to 9).toNDArray
list: org.nd4j.linalg.api.ndarray.INDArray =
[0.0, 1.0, 2.0, 3.0, , ..., 7.0, 8.0, 9.0]

scala> list(0,0)
java.lang.ArrayIndexOutOfBoundsException: 1
  at org.nd4j.api.SliceableNDArray$$anonfun$1.apply$mcI$sp(SliceableNDArray.scala:33)
  at org.nd4j.api.Implicits$IntRange.asRange(Implicits.scala:123)
  at org.nd4j.api.SliceableNDArray$class.modifyTargetIndices$1(SliceableNDArray.scala:33)
  at org.nd4j.api.SliceableNDArray$class.subMatrix(SliceableNDArray.scala:42)
  at org.nd4j.api.Implicits$RichINDArray.subMatrix(Implicits.scala:11)
  at org.nd4j.api.Implicits$RichINDArray.apply(Implicits.scala:34)
  ... 43 elided
```