### PR TITLE
fix #42 / add map functions for rows/columns/slices

### DIFF
--- a/src/main/scala/org/nd4j/api/CollectionLikeNDArray.scala
+++ b/src/main/scala/org/nd4j/api/CollectionLikeNDArray.scala
@@ -8,7 +8,7 @@ import org.nd4j.linalg.factory.Nd4j
 
 trait CollectionLikeNDArray {
   val underlying: INDArray
-
+  
   def filteri(f: Double => Boolean): INDArray = notCleanedUp { array =>
     Nd4j.getExecutioner.exec(FilterOps(underlying.linearView(), f)).z().reshape()reshape(underlying.shape():_*)
   }

--- a/src/main/scala/org/nd4j/api/ColumnProjectedNDArray.scala
+++ b/src/main/scala/org/nd4j/api/ColumnProjectedNDArray.scala
@@ -1,0 +1,30 @@
+package org.nd4j.api
+
+import org.nd4j.linalg.api.ndarray.INDArray
+
+class ColumnProjectedNDArray(val array:INDArray,filtered:Array[Int]){
+  def this(ndarray: INDArray){
+    this(ndarray,(0 until ndarray.columns()).toArray)
+  }
+
+  def mapi(f:INDArray => INDArray):INDArray = {
+    for{
+      i <- filtered
+    } array.putColumn(i,f(array.getColumn(i)))
+    array
+  }
+
+  def map(f:INDArray => INDArray):INDArray = new ColumnProjectedNDArray(array.dup(),filtered).flatMapi(f)
+
+  def flatMap(f:INDArray => INDArray):INDArray = map(f)
+
+  def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def withFilter(f:INDArray => Boolean):ColumnProjectedNDArray = {
+    val targets = for{
+      i <- filtered
+      if f(array.getColumn(i))
+    } yield i
+    new ColumnProjectedNDArray(array,targets)
+  }
+}

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -32,7 +32,19 @@ object Implicits {
     def <=(d: Double): Boolean = forall(_ <= d)
 
     def apply(target: IndexRange*): INDArray = subMatrix(target: _*)
+
+    def columnP:ColumnProjectedNDArray = new ColumnProjectedNDArray(underlying)
+
+    def rowP:RowProjectedNDArray = new RowProjectedNDArray(underlying)
+
+    def sliceP:SliceProjectedNDArray = new SliceProjectedNDArray(underlying)
   }
+
+  implicit def rowProjection2NDArray(row:RowProjectedNDArray):INDArray = row.array
+
+  implicit def columnProjection2NDArray(column:ColumnProjectedNDArray):INDArray = column.array
+
+  implicit def sliceProjection2NDArray(sliced:SliceProjectedNDArray):INDArray = sliced.array
 
   /*
    Avoid using Numeric[T].toDouble(t:T) for sequence transformation in XXColl2INDArray to minimize memory consumption.

--- a/src/main/scala/org/nd4j/api/RowProjectedNDArray.scala
+++ b/src/main/scala/org/nd4j/api/RowProjectedNDArray.scala
@@ -1,0 +1,30 @@
+package org.nd4j.api
+
+import org.nd4j.linalg.api.ndarray.INDArray
+
+class RowProjectedNDArray(val array:INDArray,filtered:Array[Int]){
+  def this(ndarray: INDArray){
+    this(ndarray,(0 until ndarray.rows()).toArray)
+  }
+
+  def mapi(f:INDArray => INDArray):INDArray = {
+    for{
+      i <- filtered
+    } array.putRow(i,f(array.getRow(i)))
+    array
+  }
+
+  def map(f:INDArray => INDArray):INDArray = new RowProjectedNDArray(array.dup(),filtered).mapi(f)
+
+  def flatMap(f:INDArray => INDArray):INDArray = map(f)
+
+  def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def withFilter(f:INDArray => Boolean):RowProjectedNDArray = {
+    val targets = for{
+      i <- filtered
+      if f(array.getRow(i))
+    } yield i
+    new RowProjectedNDArray(array,targets)
+  }
+}

--- a/src/main/scala/org/nd4j/api/SliceProjectedNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceProjectedNDArray.scala
@@ -1,0 +1,30 @@
+package org.nd4j.api
+
+import org.nd4j.linalg.api.ndarray.INDArray
+
+class SliceProjectedNDArray(val array:INDArray,filtered:Array[Int]){
+  def this(ndarray: INDArray){
+    this(ndarray,(0 until ndarray.slices()).toArray)
+  }
+
+  def mapi(f:INDArray => INDArray):INDArray = {
+    for{
+      i <- filtered
+    } array.putSlice(i,f(array.slice(i)))
+    array
+  }
+
+  def map(f:INDArray => INDArray):INDArray = new SliceProjectedNDArray(array.dup(),filtered).flatMapi(f)
+
+  def flatMap(f:INDArray => INDArray):INDArray = map(f)
+
+  def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def withFilter(f:INDArray => Boolean):SliceProjectedNDArray = {
+    val targets = for{
+      i <- filtered
+      if f(array.slice(i))
+    } yield i
+    new SliceProjectedNDArray(array,targets)
+  }
+}

--- a/src/test/scala/org/nd4j/api/NDArrayProjectionAPITest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayProjectionAPITest.scala
@@ -1,0 +1,59 @@
+package org.nd4j.api
+
+import org.scalatest.FlatSpec
+import Implicits._
+
+class NDArrayProjectionAPITest extends FlatSpec {
+  "ColumnProjectedNDArray" should "map column correctly" in {
+    val ndArray =
+      Array(
+        Array(1d, 2d, 3d),
+        Array(4d, 5d, 6d),
+        Array(7d, 8d, 9d)
+      ).toNDArray
+
+    val result = for {
+      c <- ndArray.columnP
+      if c.get(0) % 2 == 0
+    } yield c * c
+
+    assert(result == Array(
+      Array(1d, 4d, 3d),
+      Array(4d, 25d, 6d),
+      Array(7d, 64d, 9d)
+    ).toNDArray)
+  }
+
+  "RowProjectedNDArray" should "map row correctly" in {
+    val ndArray =
+      Array(
+        Array(1d, 2d, 3d),
+        Array(4d, 5d, 6d),
+        Array(7d, 8d, 9d)
+      ).toNDArray
+
+    val result = for {
+      c <- ndArray.rowP
+      if c.get(0) % 2 == 0
+    } yield c * c
+
+    assert(result == Array(
+      Array(1d, 2d, 3d),
+      Array(16d, 25d, 36d),
+      Array(7d, 8d, 9d)
+    ).toNDArray)
+  }
+
+  "SliceProjectedNDArray" should "map slice correctly" in {
+    val ndArray =
+      (1d to 8d by 1).asNDArray(2,2,2)
+
+    val result = for {
+      slice <- ndArray.sliceP
+      r <- slice.rowP
+      if r.get(0) > 1
+    } yield r * r
+
+    assert(result == List(1d,2d,9d,16d,25d,36d,49d,64d).asNDArray(2,2,2))
+  }
+}


### PR DESCRIPTION
This adds following syntaxes.

```scala
scala> val rowVector = List(1,2,3).toNDArray
scala> val ndArray =
      Array(
        Array(1d, 2d, 3d),
        Array(4d, 5d, 6d),
        Array(7d, 8d, 9d)
      ).toNDArray

scala> ndArray.rowP.map(_ + rowVector)
res0: org.nd4j.linalg.api.ndarray.INDArray =
[[2.00,4.00,6.00]
 [5.00,7.00,9.00]
 [8.00,10.00,12.00]]
```

```scala
scala> val ndArray =
      Array(
        Array(1d, 2d, 3d),
        Array(4d, 5d, 6d),
        Array(7d, 8d, 9d)
      ).toNDArray

scala> val result = for {
      c <- ndArray.columnP
      if c.get(0) % 2 == 0
    } yield c * c

result: org.nd4j.linalg.api.ndarray.INDArray =
[[1.00,4.00,3.00]
 [4.00,25.00,6.00]
 [7.00,64.00,9.00]]
```

```scala
scala> val ndArray =
      (1d to 8d by 1).asNDArray(2,2,2)
ndArray: org.nd4j.linalg.api.ndarray.INDArray =
[[[1.00,2.00]
 [3.00,4.00]]
  [[5.00,6.00]
 [7.00,8.00]]]



scala> val result = for {
      slice <- ndArray.sliceP
      r <- slice.rowP
      if r.get(0) > 1
    } yield r * r
result: org.nd4j.linalg.api.ndarray.INDArray =
[[[1.00,2.00]
 [9.00,16.00]]
  [[25.00,36.00]
 [49.00,64.00]]]
```