### PR TITLE
INDArray update with submatrix syntaxes.

### DIFF
--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -134,6 +134,8 @@ object Implicits {
     def toScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
 
+  implicit def intArray2IndexRangeArray(arr:Array[Int]):Array[IndexRange] = arr.map(new IntRange(_))
+
   case object -> extends IndexRange{
     override def hasNegative: Boolean = false
   }
@@ -177,6 +179,16 @@ object Implicits {
     override def toString: String = s"${underlying.start}->${underlying.end} by ${underlying.step}"
 
     override def hasNegative: Boolean = underlying.start < 0 || underlying.end < 0 || underlying.step < 0
+  }
+
+  implicit class NDArrayIndexWrapper(val underlying: INDArrayIndex) extends IndexNumberRange {
+    protected[api] override def asRange(max: => Int): DRange = DRange(underlying.current(),underlying.end(),false,underlying.stride(),max)
+
+    override protected[api] def asNDArrayIndex(max: => Int): INDArrayIndex = underlying
+
+    override def toString: String = s"${underlying.current}->${underlying.end} by ${underlying.stride}"
+
+    override def hasNegative: Boolean = false
   }
 
   lazy val NDOrdering = org.nd4j.api.NDOrdering

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -134,6 +134,10 @@ object Implicits {
     def toScalar: INDArray = Nd4j.scalar(ev.toDouble(underlying))
   }
 
+  implicit class icomplexNum2Scalar(val underlying: IComplexNumber){
+    def toScalar: IComplexNDArray = Nd4j.scalar(underlying)
+  }
+
   implicit def intArray2IndexRangeArray(arr:Array[Int]):Array[IndexRange] = arr.map(new IntRange(_))
 
   case object -> extends IndexRange{

--- a/src/main/scala/org/nd4j/api/Implicits.scala
+++ b/src/main/scala/org/nd4j/api/Implicits.scala
@@ -9,7 +9,7 @@ import _root_.scala.util.control.Breaks._
 
 object Implicits {
 
-  implicit class RichINDArray[A <: INDArray](val underlying: A) extends SliceableNDArray with OperatableNDArray[A] with CollectionLikeNDArray {
+  implicit class RichINDArray[A <: INDArray](val underlying: A) extends SliceableNDArray[A] with OperatableNDArray[A] with CollectionLikeNDArray[A] {
     def forall(f: Double => Boolean): Boolean = {
       var result = true
       val lv = underlying.linearView()
@@ -32,7 +32,7 @@ object Implicits {
 
     def <=(d: Double): Boolean = forall(_ <= d)
 
-    def apply(target: IndexRange*): INDArray = subMatrix(target: _*)
+    def apply[B](target: IndexRange*)(implicit ev:NDArrayEvidence[A,B],ev2:Manifest[B]):A = subMatrix(target: _*)(ev,ev2)
 
     def columnP:ColumnProjectedNDArray = new ColumnProjectedNDArray(underlying)
 

--- a/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
+++ b/src/main/scala/org/nd4j/api/NDArrayEvidence.scala
@@ -1,9 +1,10 @@
 package org.nd4j.api
 
+import org.nd4j.api.ops.FilterOps
 import org.nd4j.linalg.api.complex.{IComplexNumber, IComplexNDArray}
 import org.nd4j.linalg.api.ndarray.INDArray
-import org.nd4j.linalg.indexing.NDArrayIndex
-
+import org.nd4j.linalg.indexing.{INDArrayIndex, NDArrayIndex}
+import org.nd4j.api.Implicits._
 
 object Evidences {
   implicit val double = DoubleNDArrayEvidence
@@ -17,86 +18,98 @@ object NDArrayEvidence {
   implicit val complexNDArrayEvidence = ComplexNDArrayEvidence
 }
 
-trait NDArrayEvidence[A <: INDArray] {
-  type Value
-  type NDArray = A
+trait NDArrayEvidence[NDArray <: INDArray, Value] {
 
-  def sum(ndarray: A): Value
+  def sum(ndarray: NDArray): Value
 
-  def mean(ndarray: A): Value
+  def mean(ndarray: NDArray): Value
 
-  def normMax(ndarray: A): Value
+  def normMax(ndarray: NDArray): Value
 
-  def norm1(ndarray: A): Value
+  def norm1(ndarray: NDArray): Value
 
-  def norm2(ndarray: A): Value
+  def norm2(ndarray: NDArray): Value
 
-  def max(ndarray: A): Value
+  def max(ndarray: NDArray): Value
 
-  def min(ndarray: A): Value
+  def min(ndarray: NDArray): Value
 
-  def standardDeviation(ndarray: A): Value
+  def standardDeviation(ndarray: NDArray): Value
 
-  def product(ndarray: A): Value
+  def product(ndarray: NDArray): Value
 
-  def variance(ndarray: A): Value
+  def variance(ndarray: NDArray): Value
 
-  def add(a: A, that: INDArray): A
+  def add(a: NDArray, that: INDArray): NDArray
 
-  def sub(a: A, that: INDArray): A
+  def sub(a: NDArray, that: INDArray): NDArray
 
-  def mul(a: A, that: INDArray): A
+  def mul(a: NDArray, that: INDArray): NDArray
 
-  def mmul(a: A, that: INDArray): A
+  def mmul(a: NDArray, that: INDArray): NDArray
 
-  def div(a: A, that: INDArray): A
+  def div(a: NDArray, that: INDArray): NDArray
 
-  def rdiv(a: A, that: INDArray): A
+  def rdiv(a: NDArray, that: INDArray): NDArray
 
-  def addi(a: A, that: INDArray): A
+  def addi(a: NDArray, that: INDArray): NDArray
 
-  def subi(a: A, that: INDArray): A
+  def subi(a: NDArray, that: INDArray): NDArray
 
-  def muli(a: A, that: INDArray): A
+  def muli(a: NDArray, that: INDArray): NDArray
 
-  def mmuli(a: A, that: INDArray): A
+  def mmuli(a: NDArray, that: INDArray): NDArray
 
-  def divi(a: A, that: INDArray): A
+  def divi(a: NDArray, that: INDArray): NDArray
 
-  def rdivi(a: A, that: INDArray): A
+  def rdivi(a: NDArray, that: INDArray): NDArray
 
-  def add(a: A, that: Number): A
+  def add(a: NDArray, that: Number): NDArray
 
-  def sub(a: A, that: Number): A
+  def sub(a: NDArray, that: Number): NDArray
 
-  def mul(a: A, that: Number): A
+  def mul(a: NDArray, that: Number): NDArray
 
-  def div(a: A, that: Number): A
+  def div(a: NDArray, that: Number): NDArray
 
-  def rdiv(a: A, that: Number): A
+  def rdiv(a: NDArray, that: Number): NDArray
 
-  def addi(a: A, that: Number): A
+  def addi(a: NDArray, that: Number): NDArray
 
-  def subi(a: A, that: Number): A
+  def subi(a: NDArray, that: Number): NDArray
 
-  def muli(a: A, that: Number): A
+  def muli(a: NDArray, that: Number): NDArray
 
-  def divi(a: A, that: Number): A
+  def divi(a: NDArray, that: Number): NDArray
 
-  def rdivi(a: A, that: Number): A
+  def rdivi(a: NDArray, that: Number): NDArray
 
-  def put(a: A, i: Int, element: INDArray): A
+  def put(a: NDArray, i: Int, element: INDArray): NDArray
 
-  def put(a: A, i: Array[Int], element: INDArray): A
+  def put(a: NDArray, i: Array[Int], element: INDArray): NDArray
 
-  def get(a: A, i: Int): Value
+  def get(a: NDArray, i: Int): Value
 
-  def get(a: A, i: Int, j: Int): Value
+  def get(a: NDArray, i: Int, j: Int): Value
 
-  def get(a: A, i: Int*): Value
+  def get(a: NDArray, i: Int*): Value
+
+  def get(a: NDArray, i: INDArrayIndex*): NDArray
+
+  def reshape(a: NDArray, i: Int*): NDArray
+
+  def linearView(a: NDArray): NDArray
+
+  def dup(a: NDArray): NDArray
+
+  def create(arr: Array[Value]): NDArray
+
+  def create(arr: Array[Value], shape: Int*): NDArray
+
+  def create(arr: Array[Value], shape: Array[Int], ordering: NDOrdering, offset: Int): NDArray
 }
 
-trait RealNDArrayEvidence extends NDArrayEvidence[INDArray] {
+trait RealNDArrayEvidence[Value] extends NDArrayEvidence[INDArray, Value] {
   override def add(a: INDArray, that: INDArray): INDArray = a.add(that)
 
   override def div(a: INDArray, that: INDArray): INDArray = a.div(that)
@@ -141,93 +154,109 @@ trait RealNDArrayEvidence extends NDArrayEvidence[INDArray] {
 
   override def rdivi(a: INDArray, that: Number): INDArray = a.rdivi(that)
 
-  override def put(a: INDArray, i:Array[Int], element: INDArray): INDArray = a.put(i,element)
+  override def put(a: INDArray, i: Array[Int], element: INDArray): INDArray = a.put(i, element)
 
-  override def put(a: INDArray, i: Int, element: INDArray): INDArray = a.put(i,element)
+  override def put(a: INDArray, i: Int, element: INDArray): INDArray = a.put(i, element)
+
+  override def get(a: INDArray, i: INDArrayIndex*): INDArray = a.get(i: _*)
+
+  override def reshape(a: INDArray, i: Int*): INDArray = a.reshape(i: _*)
+
+  override def linearView(a: INDArray): INDArray = a.linearView()
+
+  override def dup(a: INDArray): INDArray = a.dup()
 }
 
-case object DoubleNDArrayEvidence extends RealNDArrayEvidence {
-  override type Value = Double
+case object DoubleNDArrayEvidence extends RealNDArrayEvidence[Double] {
 
-  override def sum(ndarray: INDArray): Value = ndarray.sumNumber().doubleValue()
+  override def sum(ndarray: INDArray): Double = ndarray.sumNumber().doubleValue()
 
-  override def mean(ndarray: INDArray): Value = ndarray.meanNumber().doubleValue()
+  override def mean(ndarray: INDArray): Double = ndarray.meanNumber().doubleValue()
 
-  override def variance(ndarray: INDArray): Value = ndarray.varNumber().doubleValue()
+  override def variance(ndarray: INDArray): Double = ndarray.varNumber().doubleValue()
 
-  override def norm2(ndarray: INDArray): Value = ndarray.norm2Number().doubleValue()
+  override def norm2(ndarray: INDArray): Double = ndarray.norm2Number().doubleValue()
 
-  override def max(ndarray: INDArray): Value = ndarray.maxNumber().doubleValue()
+  override def max(ndarray: INDArray): Double = ndarray.maxNumber().doubleValue()
 
-  override def product(ndarray: INDArray): Value = ndarray.prodNumber().doubleValue()
+  override def product(ndarray: INDArray): Double = ndarray.prodNumber().doubleValue()
 
-  override def standardDeviation(ndarray: INDArray): Value = ndarray.stdNumber().doubleValue()
+  override def standardDeviation(ndarray: INDArray): Double = ndarray.stdNumber().doubleValue()
 
-  override def normMax(ndarray: INDArray): Value = ndarray.normmaxNumber().doubleValue()
+  override def normMax(ndarray: INDArray): Double = ndarray.normmaxNumber().doubleValue()
 
-  override def min(ndarray: INDArray): Value = ndarray.minNumber().doubleValue()
+  override def min(ndarray: INDArray): Double = ndarray.minNumber().doubleValue()
 
-  override def norm1(ndarray: INDArray): Value = ndarray.norm1Number().doubleValue()
+  override def norm1(ndarray: INDArray): Double = ndarray.norm1Number().doubleValue()
 
-  override def get(a: INDArray, i: Int): Value = a.getDouble(i)
+  override def get(a: INDArray, i: Int): Double = a.getDouble(i)
 
-  override def get(a: INDArray, i: Int, j: Int): Value = a.getDouble(i,j)
+  override def get(a: INDArray, i: Int, j: Int): Double = a.getDouble(i, j)
 
-  override def get(a: INDArray, i: Int*): Value = a.getDouble(i:_*)
+  override def get(a: INDArray, i: Int*): Double = a.getDouble(i: _*)
+
+  override def create(arr: Array[Double]): INDArray = arr.toNDArray
+
+  override def create(arr: Array[Double], shape: Int*): INDArray = arr.asNDArray(shape: _*)
+
+  override def create(arr: Array[Double], shape: Array[Int], ordering: NDOrdering, offset: Int): INDArray = arr.mkNDArray(shape, ordering, offset)
 }
 
-case object FloatNDArrayEvidence extends RealNDArrayEvidence {
-  override type Value = Float
+case object FloatNDArrayEvidence extends RealNDArrayEvidence[Float] {
 
-  override def sum(ndarray: INDArray): Value = ndarray.sumNumber().floatValue()
+  override def sum(ndarray: INDArray): Float = ndarray.sumNumber().floatValue()
 
-  override def mean(ndarray: INDArray): Value = ndarray.meanNumber().floatValue()
+  override def mean(ndarray: INDArray): Float = ndarray.meanNumber().floatValue()
 
-  override def variance(ndarray: INDArray): Value = ndarray.varNumber().floatValue()
+  override def variance(ndarray: INDArray): Float = ndarray.varNumber().floatValue()
 
-  override def norm2(ndarray: INDArray): Value = ndarray.norm2Number().floatValue()
+  override def norm2(ndarray: INDArray): Float = ndarray.norm2Number().floatValue()
 
-  override def max(ndarray: INDArray): Value = ndarray.maxNumber().floatValue()
+  override def max(ndarray: INDArray): Float = ndarray.maxNumber().floatValue()
 
-  override def product(ndarray: INDArray): Value = ndarray.prodNumber().floatValue()
+  override def product(ndarray: INDArray): Float = ndarray.prodNumber().floatValue()
 
-  override def standardDeviation(ndarray: INDArray): Value = ndarray.stdNumber().floatValue()
+  override def standardDeviation(ndarray: INDArray): Float = ndarray.stdNumber().floatValue()
 
-  override def normMax(ndarray: INDArray): Value = ndarray.normmaxNumber().floatValue()
+  override def normMax(ndarray: INDArray): Float = ndarray.normmaxNumber().floatValue()
 
-  override def min(ndarray: INDArray): Value = ndarray.minNumber().floatValue()
+  override def min(ndarray: INDArray): Float = ndarray.minNumber().floatValue()
 
-  override def norm1(ndarray: INDArray): Value = ndarray.norm1Number().floatValue()
+  override def norm1(ndarray: INDArray): Float = ndarray.norm1Number().floatValue()
 
-  override def get(a: INDArray, i: Int): Value = a.getFloat(i)
+  override def get(a: INDArray, i: Int): Float = a.getFloat(i)
 
-  override def get(a: INDArray, i: Int, j: Int): Value = a.getFloat(i,j)
+  override def get(a: INDArray, i: Int, j: Int): Float = a.getFloat(i, j)
 
-  override def get(a: INDArray, i: Int*): Value = a.getFloat(i.toArray)
+  override def get(a: INDArray, i: Int*): Float = a.getFloat(i.toArray)
+
+  override def create(arr: Array[Float]): INDArray = arr.toNDArray
+
+  override def create(arr: Array[Float], shape: Int*): INDArray = arr.asNDArray(shape: _*)
+
+  override def create(arr: Array[Float], shape: Array[Int], ordering: NDOrdering, offset: Int): INDArray = arr.mkNDArray(shape, ordering, offset)
 }
 
-case object ComplexNDArrayEvidence extends NDArrayEvidence[IComplexNDArray] {
-  override type Value = IComplexNumber
+case object ComplexNDArrayEvidence extends NDArrayEvidence[IComplexNDArray, IComplexNumber] {
+  override def sum(ndarray: IComplexNDArray): IComplexNumber = ndarray.sumComplex()
 
-  override def sum(ndarray: IComplexNDArray): Value = ndarray.sumComplex()
+  override def mean(ndarray: IComplexNDArray): IComplexNumber = ndarray.meanComplex()
 
-  override def mean(ndarray: IComplexNDArray): Value = ndarray.meanComplex()
+  override def variance(ndarray: IComplexNDArray): IComplexNumber = ndarray.varComplex()
 
-  override def variance(ndarray: IComplexNDArray): Value = ndarray.varComplex()
+  override def norm2(ndarray: IComplexNDArray): IComplexNumber = ndarray.norm2Complex()
 
-  override def norm2(ndarray: IComplexNDArray): Value = ndarray.norm2Complex()
+  override def max(ndarray: IComplexNDArray): IComplexNumber = ndarray.maxComplex()
 
-  override def max(ndarray: IComplexNDArray): Value = ndarray.maxComplex()
+  override def product(ndarray: IComplexNDArray): IComplexNumber = ndarray.prodComplex()
 
-  override def product(ndarray: IComplexNDArray): Value = ndarray.prodComplex()
+  override def standardDeviation(ndarray: IComplexNDArray): IComplexNumber = ndarray.stdComplex()
 
-  override def standardDeviation(ndarray: IComplexNDArray): Value = ndarray.stdComplex()
+  override def normMax(ndarray: IComplexNDArray): IComplexNumber = ndarray.normmaxComplex()
 
-  override def normMax(ndarray: IComplexNDArray): Value = ndarray.normmaxComplex()
+  override def min(ndarray: IComplexNDArray): IComplexNumber = ndarray.minComplex()
 
-  override def min(ndarray: IComplexNDArray): Value = ndarray.minComplex()
-
-  override def norm1(ndarray: IComplexNDArray): Value = ndarray.norm1Complex()
+  override def norm1(ndarray: IComplexNDArray): IComplexNumber = ndarray.norm1Complex()
 
   override def add(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.add(that)
 
@@ -273,13 +302,27 @@ case object ComplexNDArrayEvidence extends NDArrayEvidence[IComplexNDArray] {
 
   override def mmuli(a: IComplexNDArray, that: INDArray): IComplexNDArray = a.mmuli(that)
 
-  override def get(a: IComplexNDArray, i: Int): Value = a.getComplex(i)
+  override def get(a: IComplexNDArray, i: Int): IComplexNumber = a.getComplex(i)
 
-  override def get(a: IComplexNDArray, i: Int, j: Int): Value = a.getComplex(i,j)
+  override def get(a: IComplexNDArray, i: Int, j: Int): IComplexNumber = a.getComplex(i, j)
 
-  override def get(a: IComplexNDArray, i: Int*): Value = a.getComplex(i:_*)
+  override def get(a: IComplexNDArray, i: Int*): IComplexNumber = a.getComplex(i: _*)
 
-  override def put(a: IComplexNDArray, i: Int, element: INDArray): IComplexNDArray = a.put(i,element)
+  override def get(a: IComplexNDArray, i: INDArrayIndex*): IComplexNDArray = a.get(i: _*)
 
-  override def put(a: IComplexNDArray, i: Array[Int], element: INDArray): IComplexNDArray = a.put(i,element)
+  override def put(a: IComplexNDArray, i: Int, element: INDArray): IComplexNDArray = a.put(i, element)
+
+  override def put(a: IComplexNDArray, i: Array[Int], element: INDArray): IComplexNDArray = a.put(i, element)
+
+  override def reshape(a: IComplexNDArray, i: Int*): IComplexNDArray = a.reshape(i: _*)
+
+  override def linearView(a: IComplexNDArray): IComplexNDArray = a.linearView()
+
+  override def dup(a: IComplexNDArray): IComplexNDArray = a.dup()
+
+  override def create(arr: Array[IComplexNumber]): IComplexNDArray = arr.toNDArray
+
+  override def create(arr: Array[IComplexNumber], shape: Int*):IComplexNDArray = arr.asNDArray(shape: _*)
+
+  override def create(arr: Array[IComplexNumber], shape: Array[Int], ordering: NDOrdering, offset: Int): IComplexNDArray = arr.mkNDArray(shape, ordering, offset)
 }

--- a/src/main/scala/org/nd4j/api/OperatableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/OperatableNDArray.scala
@@ -108,26 +108,6 @@ trait OperatableNDArray[A <: INDArray] {
 
   def get[B](indices: Array[Int])(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,indices: _*)
 
-  def update[B](i: Int, element: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.put(underlying,i, element)
-
-  def update[B](indices: Array[Int], element: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.put(underlying, indices, element)
-
-  def update(indices: Array[INDArrayIndex], element: INDArray): INDArray = underlying.put(indices, element)
-
-  def update(i: Int, j: Int, element: INDArray): INDArray = underlying.put(i, j, element)
-
-  def update(i: Int, value: Double): INDArray = underlying.putScalar(i, value)
-
-  def update(i: Int, value: Float): INDArray = underlying.putScalar(i, value)
-
-  def update(i: Int, value: Int): INDArray = underlying.putScalar(i, value)
-
-  def update(i: Array[Int], value: Double): INDArray = underlying.putScalar(i, value)
-
-  def update(i: Array[Int], value: Float): INDArray = underlying.putScalar(i, value)
-
-  def update(i: Array[Int], value: Int): INDArray = underlying.putScalar(i, value)
-
   def unary_-(): INDArray = underlying.neg()
 
   def T: INDArray = underlying.transpose()

--- a/src/main/scala/org/nd4j/api/OperatableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/OperatableNDArray.scala
@@ -31,65 +31,65 @@ trait OperatableNDArray[A <: INDArray] {
   val underlying: A
 
   // --- INDArray operators
-  def +(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.add(underlying,that)
+  def +[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.add(underlying,that)
 
-  def -(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.sub(underlying,that)
+  def -[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.sub(underlying,that)
 
   /** element-by-element multiplication */
-  def *(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mul(underlying,that)
-
+  def *[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.mul(underlying,that)
+                                                        
   /** matrix multiplication */
-  def **(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmul(underlying,that)
+  def **[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.mmul(underlying,that)
 
   /** matrix multiplication using Numpy syntax for arrays */
-  def dot(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmul(underlying,that)
+  def dot[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.mmul(underlying,that)
 
-  def /(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray  = ev.div(underlying,that)
+  def /[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A  = ev.div(underlying,that)
 
   /** right division ... is this the correct symbol? */
-  def \(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray  = ev.rdiv(underlying,that)
+  def \[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A  = ev.rdiv(underlying,that)
 
   // --- In-place INDArray opertors
   /** In-place addition */
-  def +=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.addi(underlying,that)
+  def +=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.addi(underlying,that)
 
   /** In-place subtraction */
-  def -=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.subi(underlying,that)
+  def -=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.subi(underlying,that)
 
   /** In-placeelement-by-element multiplication */
-  def *=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.muli(underlying,that)
+  def *=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.muli(underlying,that)
 
   /** In-place matrix multiplication */
-  def **=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mmuli(underlying,that)
+  def **=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.mmuli(underlying,that)
 
   /** In-place division */
-  def /=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.divi(underlying,that)
+  def /=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.divi(underlying,that)
 
   /** In-place right division */
-  def \=(that: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdivi(underlying,that)
+  def \=[B](that: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.rdivi(underlying,that)
 
   // --- Number operators
-  def +(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.add(underlying,that)
+  def +[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.add(underlying,that)
 
-  def -(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.sub(underlying,that)
+  def -[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.sub(underlying,that)
 
-  def *(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.mul(underlying,that)
+  def *[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.mul(underlying,that)
 
-  def /(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.div(underlying,that)
+  def /[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.div(underlying,that)
 
-  def \(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdiv(underlying,that)
+  def \[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.rdiv(underlying,that)
 
   // --- In-place Number operators
-  def +=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.addi(underlying,that)
+  def +=[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.addi(underlying,that)
 
-  def -=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.subi(underlying,that)
+  def -=[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.subi(underlying,that)
 
-  def *=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.muli(underlying,that)
+  def *=[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.muli(underlying,that)
 
-  def /=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.divi(underlying,that)
+  def /=[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.divi(underlying,that)
 
   /** right division ... is this the correct symbol? */
-  def \=(that: Number)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.rdivi(underlying,that)
+  def \=[B](that: Number)(implicit ev:NDArrayEvidence[A,B]): A = ev.rdivi(underlying,that)
 
   // --- Complex operators
   def +(that: IComplexNumber): IComplexNDArray = underlying.add(that)
@@ -100,17 +100,17 @@ trait OperatableNDArray[A <: INDArray] {
 
   def /(that: IComplexNumber): IComplexNDArray = underlying.div(that)
 
-  def get(i: Int)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,i)
+  def get[B](i: Int)(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,i)
 
-  def get(i: Int, j: Int)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,i, j)
+  def get[B](i: Int, j: Int)(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,i, j)
 
-  def get(indices: Int*)(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,indices: _*)
+  def get[B](indices: Int*)(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,indices: _*)
 
-  def get(indices: Array[Int])(implicit ev:NDArrayEvidence[A]): ev.Value = ev.get(underlying,indices: _*)
+  def get[B](indices: Array[Int])(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,indices: _*)
 
-  def update(i: Int, element: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.put(underlying,i, element)
+  def update[B](i: Int, element: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.put(underlying,i, element)
 
-  def update(indices: Array[Int], element: INDArray)(implicit ev:NDArrayEvidence[A]): ev.NDArray = ev.put(underlying, indices, element)
+  def update[B](indices: Array[Int], element: INDArray)(implicit ev:NDArrayEvidence[A,B]): A = ev.put(underlying, indices, element)
 
   def update(indices: Array[INDArrayIndex], element: INDArray): INDArray = underlying.put(indices, element)
 
@@ -136,23 +136,23 @@ trait OperatableNDArray[A <: INDArray] {
 
   def ===(other: INDArray): INDArray = underlying.eq(other)
 
-  def sumT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.sum(underlying)
+  def sumT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.sum(underlying)
 
-  def meanT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.sum(underlying)
+  def meanT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.sum(underlying)
 
-  def normMaxT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.normMax(underlying)
+  def normMaxT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.normMax(underlying)
 
-  def norm1T(implicit ev: NDArrayEvidence[A]): ev.Value = ev.norm1(underlying)
+  def norm1T[B](implicit ev: NDArrayEvidence[A,B]): B = ev.norm1(underlying)
 
-  def norm2T(implicit ev: NDArrayEvidence[A]): ev.Value = ev.norm2(underlying)
+  def norm2T[B](implicit ev: NDArrayEvidence[A,B]): B = ev.norm2(underlying)
 
-  def maxT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.max(underlying)
+  def maxT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.max(underlying)
 
-  def minT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.min(underlying)
+  def minT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.min(underlying)
 
-  def stdT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.standardDeviation(underlying)
+  def stdT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.standardDeviation(underlying)
 
-  def prodT(implicit ev: NDArrayEvidence[A]): ev.Value = ev.product(underlying)
+  def prodT[B](implicit ev: NDArrayEvidence[A,B]): B = ev.product(underlying)
 
-  def varT()(implicit ev: NDArrayEvidence[A]): ev.Value = ev.variance(underlying)
+  def varT[B]()(implicit ev: NDArrayEvidence[A,B]): B = ev.variance(underlying)
 }

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -18,7 +18,7 @@ trait SliceableNDArray [A <: INDArray]{
   def subMatrix[B](target: IndexRange*)(implicit ev:NDArrayEvidence[A,B],ev2:Manifest[B]): A = {
     require(target.size <= underlying.shape().length, "Matrix dimension must be equal or larger than shape's dimension to extract.")
 
-    if(underlying.isRowVector || target.exists(_.hasNegative)) {
+//    if(underlying.isRowVector || target.exists(_.hasNegative)) {
       val SubMatrixIndices(indices,targetShape) = indicesFrom(target:_*)
 
       val lv = ev.linearView(underlying)
@@ -26,9 +26,9 @@ trait SliceableNDArray [A <: INDArray]{
 
       ev.create(filtered, targetShape, NDOrdering(underlying.ordering()),0)
 
-    }else{
-      ev.get(underlying,getINDArrayIndexfrom(target:_*):_*)
-    }
+//    }else{
+//      ev.get(underlying,getINDArrayIndexfrom(target:_*):_*)
+//    }
   }
 
   def indicesFrom(target:IndexRange*):SubMatrixIndices = {

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -1,6 +1,7 @@
 package org.nd4j.api
 
 import org.nd4j.api.Implicits._
+import org.nd4j.linalg.api.complex.{IComplexNDArray, IComplexNumber}
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.nd4j.linalg.indexing.{NDArrayIndex, INDArrayIndex}
 import org.slf4j.LoggerFactory
@@ -108,5 +109,45 @@ trait SliceableNDArray [A <: INDArray]{
 
     modifyTargetIndices(originalTarget.toList, 0, Nil)
   }
+
+  def update(ir:Array[IndexRange],num:Double):INDArray = {
+    indicesFrom(ir: _*).indices.foreach { i =>
+      underlying.putScalar(i, num)
+    }
+    underlying
+  }
+  def update(i1:IndexRange,num:Double):INDArray = update(Array(i1),num)
+  def update(i1:IndexRange,i2:IndexRange,num:Double):INDArray = update(Array(i1,i2),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:Double):INDArray =  update(Array(i1,i2,i3,i4),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:Double):INDArray =  update(Array(i1,i2,i3,i4,i5),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:Double):INDArray  = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
+
+
+  def update(ir:Array[IndexRange],num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = {
+    val u = underlying.asInstanceOf[IComplexNDArray]
+    indicesFrom(ir: _*).indices.foreach { i =>
+      u.putScalar(i, num)
+    }
+    u
+  }
+  def update(i1:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1),num)
+  def update(i1:IndexRange,i2:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray =  update(Array(i1,i2,i3,i4),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray =  update(Array(i1,i2,i3,i4,i5),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray  = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
 }
 case class SubMatrixIndices(indices:List[Int],targetShape:Array[Int])

--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -7,72 +7,77 @@ import org.slf4j.LoggerFactory
 
 import _root_.scala.annotation.tailrec
 
-trait SliceableNDArray {
-  lazy val log = LoggerFactory.getLogger(classOf[SliceableNDArray])
-  val underlying: INDArray
+trait SliceableNDArray [A <: INDArray]{
+  lazy val log = LoggerFactory.getLogger(classOf[SliceableNDArray[A]])
+  val underlying:A
 
   /*
     Extract subMatrix at given position.
   */
-  def subMatrix(target: IndexRange*): INDArray = {
+  def subMatrix[B](target: IndexRange*)(implicit ev:NDArrayEvidence[A,B],ev2:Manifest[B]): A = {
     require(target.size <= underlying.shape().length, "Matrix dimension must be equal or larger than shape's dimension to extract.")
 
     if(underlying.isRowVector || target.exists(_.hasNegative)) {
-      val originalShape = if (underlying.isRowVector && underlying.shape().length == 1)
-        1 +: underlying.shape()
-      else
-        underlying.shape()
+      val SubMatrixIndices(indices,targetShape) = indicesFrom(target:_*)
 
-      val originalTarget = if (underlying.isRowVector && target.size == 1)
-        IntRange(0) +: target
-      else
-        target
+      val lv = ev.linearView(underlying)
+      val filtered = indices.map { i => ev.get(lv,i)}.toArray
 
-      @tailrec
-      def modifyTargetIndices(input: List[IndexRange], i: Int, acc: List[DRange]): List[DRange] = input match {
-        case -> :: t => modifyTargetIndices(t, i + 1, DRange(0, originalShape(i), 1) :: acc)
-        case ---> :: t =>
-          val ellipsised = List.fill(originalShape.length - i - t.size)(->)
-          modifyTargetIndices(ellipsised ::: t, i, acc)
-        case IntRangeFrom(from: Int) :: t =>
-          val max = originalShape(i)
-          modifyTargetIndices(t, i + 1, DRange(from, max, false, 1, max) :: acc)
-        case (inr: IndexNumberRange) :: t =>
-          modifyTargetIndices(t, i + 1, inr.asRange(originalShape(i)) :: acc)
-
-        case Nil =>
-          acc.reverse
-      }
-
-      val modifiedTarget = modifyTargetIndices(originalTarget.toList, 0, Nil)
-
-      val targetShape = modifiedTarget.map(_.length).toArray
-
-      def calcIndices(tgt: List[DRange], stride: List[Int]): List[Int] = {
-        val indicesOnAxis = (tgt zip stride).collect {
-          case (range, st) => range.toList.map(_ * st)
-        }
-        indicesOnAxis.reduceLeft[List[Int]] { case (l, r) =>
-          if (underlying.ordering() == NDOrdering.C.value)
-            l.flatMap { i => r.map(_ + i)}
-          else
-            r.flatMap { i => l.map(_ + i)}
-        }
-      }
-
-      val indices = calcIndices(modifiedTarget.toList, underlying.stride().toList)
-
-      log.trace(s"${target.mkString("[", ",", "]")} means $modifiedTarget at ${originalShape.mkString("[", "x", s"]${underlying.ordering}")} matrix with stride:${underlying.stride.mkString(",")}. Target shape:${targetShape.mkString("[", "x", s"]${underlying.ordering}")} indices:$indices")
-
-      val lv = underlying.linearView()
-      val filtered = indices.map { i => lv.getDouble(i)}
-
-      filtered.mkNDArray(targetShape, NDOrdering(underlying.ordering()), 0)
+      ev.create(filtered, targetShape, NDOrdering(underlying.ordering()),0)
 
     }else{
-      underlying.get(getINDArrayIndexfrom(target:_*):_*)
+      ev.get(underlying,getINDArrayIndexfrom(target:_*):_*)
     }
   }
+
+  def indicesFrom(target:IndexRange*):SubMatrixIndices = {
+    val originalShape = if (underlying.isRowVector && underlying.shape().length == 1)
+      1 +: underlying.shape()
+    else
+      underlying.shape()
+
+    val originalTarget = if (underlying.isRowVector && target.size == 1)
+      IntRange(0) +: target
+    else
+      target
+
+    @tailrec
+    def modifyTargetIndices(input: List[IndexRange], i: Int, acc: List[DRange]): List[DRange] = input match {
+      case -> :: t => modifyTargetIndices(t, i + 1, DRange(0, originalShape(i), 1) :: acc)
+      case ---> :: t =>
+        val ellipsised = List.fill(originalShape.length - i - t.size)(->)
+        modifyTargetIndices(ellipsised ::: t, i, acc)
+      case IntRangeFrom(from: Int) :: t =>
+        val max = originalShape(i)
+        modifyTargetIndices(t, i + 1, DRange(from, max, false, 1, max) :: acc)
+      case (inr: IndexNumberRange) :: t =>
+        modifyTargetIndices(t, i + 1, inr.asRange(originalShape(i)) :: acc)
+
+      case Nil =>
+        acc.reverse
+    }
+
+    val modifiedTarget = modifyTargetIndices(originalTarget.toList, 0, Nil)
+
+    val targetShape = modifiedTarget.map(_.length).toArray
+
+    def calcIndices(tgt: List[DRange], stride: List[Int]): List[Int] = {
+      val indicesOnAxis = (tgt zip stride).collect {
+        case (range, st) => range.toList.map(_ * st)
+      }
+      indicesOnAxis.reduceLeft[List[Int]] { case (l, r) =>
+        if (underlying.ordering() == NDOrdering.C.value)
+          l.flatMap { i => r.map(_ + i)}
+        else
+          r.flatMap { i => l.map(_ + i)}
+      }
+    }
+
+    val indices = calcIndices(modifiedTarget.toList, underlying.stride().toList)
+    log.trace(s"${target.mkString("[", ",", "]")} means $modifiedTarget at ${originalShape.mkString("[", "x", s"]${underlying.ordering}")} matrix with stride:${underlying.stride.mkString(",")}. Target shape:${targetShape.mkString("[", "x", s"]${underlying.ordering}")} indices:$indices")
+    SubMatrixIndices(indices,targetShape)
+  }
+
 
   def getINDArrayIndexfrom(target: IndexRange*):List[INDArrayIndex] ={
     val originalShape = if (underlying.isRowVector && underlying.shape().length == 1)
@@ -104,3 +109,4 @@ trait SliceableNDArray {
     modifyTargetIndices(originalTarget.toList, 0, Nil)
   }
 }
+case class SubMatrixIndices(indices:List[Int],targetShape:Array[Int])

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -3,6 +3,7 @@ package org.nd4j.api
 import org.nd4j.api.Implicits._
 import org.scalatest.FlatSpec
 
+
 class NDArrayExtractionTest extends FlatSpec{
   "org.nd4j.api.Implicits.RichNDArray" should "provides forall checker" in {
     val ndArray =
@@ -224,6 +225,23 @@ class NDArrayExtractionTest extends FlatSpec{
     assert(nStep.getFloat(1) == 6)
     assert(nStep.getFloat(2) == 5)
     assert(nStep.getFloat(3) == 4)
+  }
+
+  it should "be able to update with specified indices" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    ndArray(0 -> 3 by 2, ->) = 0
+
+    assert(ndArray == Array(
+      Array(0, 0, 0),
+      Array(4, 5, 6),
+      Array(0, 0, 0)
+    ).toNDArray)
   }
 
   "num2Scalar" should "convert number to Scalar INDArray" in {

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -1,6 +1,8 @@
 package org.nd4j.api
 
 import org.nd4j.api.Implicits._
+import org.nd4j.linalg.api.complex.IComplexNDArray
+import org.nd4j.linalg.factory.Nd4j
 import org.scalatest.FlatSpec
 
 
@@ -225,6 +227,18 @@ class NDArrayExtractionTest extends FlatSpec{
     assert(nStep.getFloat(1) == 6)
     assert(nStep.getFloat(2) == 5)
     assert(nStep.getFloat(3) == 4)
+  }
+
+  it should "work with ComplexNDArray correctly" in {
+    val complexNDArray =
+      Array(
+        Array(1 + i, 1 + i),
+        Array(1 + 3 * i, 1 + 3 * i)
+      ).toNDArray
+
+    val result = complexNDArray(0,0)
+
+    assert(result == (1 + i).toScalar)
   }
 
   it should "be able to update with specified indices" in {


### PR DESCRIPTION
This adds the following syntaxes.

```scala
    val ndArray =
      Array(
        Array(1, 2, 3),
        Array(4, 5, 6),
        Array(7, 8, 9)
      ).toNDArray

    ndArray(0 -> 3 by 2, ->) = 0

    assert(ndArray == Array(
      Array(0, 0, 0),
      Array(4, 5, 6),
      Array(0, 0, 0)
    ).toNDArray)
```

... and also IComplexNDArray support.