### PR TITLE
fixes indices calculation from IComplexNDArray strides

### DIFF
--- a/src/main/scala/org/nd4j/api/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4j/api/SliceableNDArray.scala
@@ -3,6 +3,7 @@ package org.nd4j.api
 import org.nd4j.api.Implicits._
 import org.nd4j.linalg.api.complex.{IComplexNDArray, IComplexNumber}
 import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
 import org.nd4j.linalg.indexing.{NDArrayIndex, INDArrayIndex}
 import org.slf4j.LoggerFactory
 
@@ -74,7 +75,7 @@ trait SliceableNDArray [A <: INDArray]{
       }
     }
 
-    val indices = calcIndices(modifiedTarget.toList, underlying.stride().toList)
+    val indices = calcIndices(modifiedTarget.toList, Nd4j.getStrides(originalShape,underlying.ordering()).toList)
     log.trace(s"${target.mkString("[", ",", "]")} means $modifiedTarget at ${originalShape.mkString("[", "x", s"]${underlying.ordering}")} matrix with stride:${underlying.stride.mkString(",")}. Target shape:${targetShape.mkString("[", "x", s"]${underlying.ordering}")} indices:$indices")
     SubMatrixIndices(indices,targetShape)
   }

--- a/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4j/api/NDArrayExtractionTest.scala
@@ -239,6 +239,10 @@ class NDArrayExtractionTest extends FlatSpec{
     val result = complexNDArray(0,0)
 
     assert(result == (1 + i).toScalar)
+
+    val result2 = complexNDArray(->,0)
+
+    assert(result2 == Array(Array(1 + i),Array(1 + 3*i)).toNDArray)
   }
 
   it should "be able to update with specified indices" in {


### PR DESCRIPTION
This fixes indicies calculation with stride of IComplexNDArray since IComplexNDArray stride is always multiplied by 2 (due to real and imaginary component)