### PR TITLE
adds release information for sbt / ref #54

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.sbt.pgp.PgpKeys
+
 lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M1"),
@@ -15,5 +17,47 @@ lazy val root = (project in file(".")).settings(
     }
   ),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"),
-  initialCommands in console := "import org.nd4j.linalg.factory.Nd4j; import org.nd4j.api.Implicits._"
+  initialCommands in console := "import org.nd4j.linalg.factory.Nd4j; import org.nd4j.api.Implicits._",
+  publishMavenStyle := true,
+  publishArtifact in Test := false,
+  pomIncludeRepository := {_ => false},
+  publishTo <<= version {
+    v =>
+      val nexus = "https://oss.sonatype.org/"
+      if (v.trim.endsWith("SNAPSHOT"))
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  },
+ pomExtra := {
+   <url>http://nd4s.org/</url>
+     <licenses>
+       <license>
+         <name>Apache License, Version 2.0</name>
+         <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+         <distribution>repo</distribution>
+       </license>
+     </licenses>
+     <scm>
+       <connection>scm:git@github.com:SkymindIO/nd4s.git</connection>
+       <developerConnection>scm:git:git@github.com:SkymindIO/nd4s.git</developerConnection>
+       <url>git@github.com:deeplearning4j/nd4s.git</url>
+       <tag>HEAD</tag>
+     </scm>
+     <developers>
+       <developer>
+         <id>agibsonccc</id>
+         <name>Adam Gibson</name>
+         <email>adam@skymind.io</email>
+       </developer>
+       <developer>
+         <id>taisukeoe</id>
+         <name>Taisuke Oe</name>
+         <email>oeuia.t@gmail.com</email>
+       </developer>
+     </developers>
+ },
+  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  releaseCrossBuild := true
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
This adds required information to build.sbt for release.

Please be noted that you'll need to setup sonatype credentials at `~ /.ivy2 /.credentials` like:
```
realm=Sonatype Nexus Repository Manager
host=oss.sonatype.org
user=admin
password=admin123
```
http://www.scala-sbt.org/0.13/docs/Publishing.html#Credentials

Then you'll be able to release with `sbt release` though I couldn't confirm it due to the lack of Credentials.... :)

@agibsonccc 
Would you please review especially for pomExtra?