### PR TITLE
[Do not merge] fixes #59 / adds update function with INDArray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,13 @@
-import com.typesafe.sbt.pgp.PgpKeys
-
 lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M1"),
   name := "nd4s",
-  version := "0.4-rc1.1",
+  version := "0.4-rc2.2-SNAPSHOT",
   organization := "org.nd4j",
   resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",
   libraryDependencies ++= Seq(
-    "org.nd4j" % "nd4j-api" % "0.4-rc1.1",
-    "org.nd4j" % "nd4j-jblas" % "0.4-rc1.1" % Test,
+    "org.nd4j" % "nd4j-api" % "0.4-rc2.2-SNAPSHOT",
+    "org.nd4j" % "nd4j-jblas" % "0.4-rc2.2-SNAPSHOT" % Test,
     "ch.qos.logback" % "logback-classic" %  "1.1.3" % Test,
     "org.scalatest" %% "scalatest" % "2.2.4" % Test cross CrossVersion.binaryMapped {
       case x if x startsWith "2.12" => "2.11"
@@ -57,6 +55,7 @@ lazy val root = (project in file(".")).settings(
       </developers>
   },
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+  releasePublishArtifactsAction := com.typesafe.sbt.pgp.PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
   initialCommands in console := "import org.nd4j.linalg.factory.Nd4j; import org.nd4s.Implicits._")
+

--- a/src/main/scala/org/nd4s/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4s/SliceableNDArray.scala
@@ -116,44 +116,32 @@ trait SliceableNDArray [A <: INDArray]{
     modifiedTarget
   }
 
-  def update(ir:Array[IndexRange],num:Double):INDArray = {
-    indicesFrom(ir: _*).indices.foreach { i =>
-      underlying.putScalar(i, num)
-    }
-    underlying
-  }
-  def update(i1:IndexRange,num:Double):INDArray = update(Array(i1),num)
-  def update(i1:IndexRange,i2:IndexRange,num:Double):INDArray = update(Array(i1,i2),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:Double):INDArray =  update(Array(i1,i2,i3,i4),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:Double):INDArray =  update(Array(i1,i2,i3,i4,i5),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:Double):INDArray  = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:Double):INDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
+  def update[T,T1](indices:Array[IndexRange],num:T)(implicit ev:NDArrayEvidence[A,T1],ev2:T => T1):INDArray = ev.update(underlying,indices,num)
+  def update[T,T1](i1:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1],ev2:T => T1):INDArray = ev.update(underlying,Array(i1),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray =  ev.update(underlying,Array(i1,i2,i3,i4),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray =  ev.update(underlying,Array(i1,i2,i3,i4,i5),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray  = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
+  def update[T,T1](i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:T)(implicit ev:NDArrayEvidence[A,T1], ev2:T => T1):INDArray = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
 
-
-  def update(ir:Array[IndexRange],num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = {
-    val u = underlying.asInstanceOf[IComplexNDArray]
-    indicesFrom(ir: _*).indices.foreach { i =>
-      u.putScalar(i, num)
-    }
-    u
-  }
-  def update(i1:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1),num)
-  def update(i1:IndexRange,i2:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray =  update(Array(i1,i2,i3,i4),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray =  update(Array(i1,i2,i3,i4,i5),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray  = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
-  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:IComplexNumber)(implicit ev: A =:= IComplexNDArray):IComplexNDArray = update(Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
+  def update(indices:Array[IndexRange],num:A)(implicit ev:NDArrayEvidence[A,_]):INDArray = ev.update(underlying,indices,num)
+  def update(i1:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1),num)
+  def update(i1:IndexRange,i2:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A =  ev.update(underlying,Array(i1,i2,i3,i4),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A =  ev.update(underlying,Array(i1,i2,i3,i4,i5),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A  = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11),num)
+  def update(i1:IndexRange,i2:IndexRange,i3:IndexRange,i4:IndexRange,i5:IndexRange,i6:IndexRange,i7:IndexRange,i8:IndexRange,i9:IndexRange,i10:IndexRange,i11:IndexRange,i12:IndexRange,num:A)(implicit ev:NDArrayEvidence[A,_]):A = ev.update(underlying,Array(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12),num)
 }
 case class SubMatrixIndices(indices:List[Int],targetShape:Array[Int])

--- a/src/test/scala/org/nd4s/NDArrayExtractionTest.scala
+++ b/src/test/scala/org/nd4s/NDArrayExtractionTest.scala
@@ -245,7 +245,7 @@ class NDArrayExtractionTest extends FlatSpec{
     assert(result2 == Array(Array(1 + i),Array(1 + 3*i)).toNDArray)
   }
 
-  it should "be able to update with specified indices" in {
+  it should "be able to update value with specified indices" in {
     val ndArray =
       Array(
         Array(1, 2, 3),
@@ -259,6 +259,23 @@ class NDArrayExtractionTest extends FlatSpec{
       Array(0, 0, 0),
       Array(4, 5, 6),
       Array(0, 0, 0)
+    ).toNDArray)
+  }
+
+  it should "be able to update INDArray with specified indices" in {
+    val ndArray =
+      Array(
+        Array(1, 2, 3),
+        Array(4, 5, 6),
+        Array(7, 8, 9)
+      ).toNDArray
+
+    ndArray(0 -> 2, 0 -> 2) = Array(Array(0,1),Array(2,3)).toNDArray
+
+    assert(ndArray == Array(
+      Array(0, 1, 3),
+      Array(2, 3, 6),
+      Array(7, 8, 9)
     ).toNDArray)
   }
 

--- a/src/test/scala/org/nd4s/OperatableNDArrayTest.scala
+++ b/src/test/scala/org/nd4s/OperatableNDArrayTest.scala
@@ -126,7 +126,7 @@ class OperatableNDArrayTest extends FlatSpec with Matchers {
     b.get(1) should be(-3)
   }
 
-  it should "workd with ComplexNDArray correctly" in {
+  it should "worked with ComplexNDArray correctly" in {
     val complexNDArray =
       Array(
         Array(1 + i, 1 + i),


### PR DESCRIPTION
This adds following syntax.

```scala
scala> val m = Nd4j.create(2,2)
m: org.nd4j.linalg.api.ndarray.INDArray =
[[0.00,0.00]
 [0.00,0.00]]

scala> m(0, ->) = Array(1.0,2.0).toNDArray
res0: org.nd4j.linalg.api.ndarray.INDArray =
[[1.00,2.00]
 [0.00,0.00]]
```

Of note, currently DL4S test fails due to the following bug in ND4J.
So this should not be merged until it's fixed.

```scala
scala>   val ndArray =
     |       Array(
     |         Array(1, 2, 3),
     |         Array(4, 5, 6),
     |         Array(7, 8, 9)
     |       ).toNDArray
ndArray: org.nd4j.linalg.api.ndarray.INDArray =
[[1.00,2.00,3.00]
 [4.00,5.00,6.00]
 [7.00,8.00,9.00]]

//this should return [[0.00,0.00,0.00] [0.00,0.00,0.00]] instead.
scala> ndArray.put(Array(NDArrayIndex.interval(0,2,3,false),NDArrayIndex.all),0)
res6: org.nd4j.linalg.api.ndarray.INDArray =
[[0.00,2.00,3.00]
 [7.00,8.00,9.00]]
```