### PR TITLE
Adding value extraction syntax

### DIFF
--- a/src/main/scala/org/nd4s/OperatableNDArray.scala
+++ b/src/main/scala/org/nd4s/OperatableNDArray.scala
@@ -106,6 +106,12 @@ trait OperatableNDArray[A <: INDArray] {
 
   def get[B](indices: Int*)(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,indices: _*)
 
+  def apply[B](i: Int)(implicit ev:NDArrayEvidence[A,B]): B = get(i)
+
+  def apply[B](i: Int, j: Int)(implicit ev:NDArrayEvidence[A,B]): B = get(i,j)
+
+  def apply[B](indices: Int*)(implicit ev:NDArrayEvidence[A,B]): B = get(indices: _*)
+
   def get[B](indices: Array[Int])(implicit ev:NDArrayEvidence[A,B]): B = ev.get(underlying,indices: _*)
 
   def unary_-(): INDArray = underlying.neg()

--- a/src/main/scala/org/nd4s/SliceableNDArray.scala
+++ b/src/main/scala/org/nd4s/SliceableNDArray.scala
@@ -19,7 +19,7 @@ trait SliceableNDArray [A <: INDArray]{
   def subMatrix[B](target: IndexRange*)(implicit ev:NDArrayEvidence[A,B],ev2:Manifest[B]): A = {
     require(target.size <= underlying.shape().length, "Matrix dimension must be equal or larger than shape's dimension to extract.")
 
-    if(underlying.isRowVector || target.exists(_.hasNegative)) {
+    if(target.exists(_.hasNegative)) {
       val SubMatrixIndices(indices,targetShape) = indicesFrom(target:_*)
 
       val lv = ev.linearView(underlying)

--- a/src/test/scala/org/nd4s/ComplexNDArrayTest.scala
+++ b/src/test/scala/org/nd4s/ComplexNDArrayTest.scala
@@ -1,0 +1,38 @@
+package org.nd4s
+
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4s.Implicits._
+import org.scalatest.{BeforeAndAfter, FlatSpec}
+
+class ComplexNDArrayInCOrderTest extends ComplexNDArrayTestBase with COrderingForTest
+class ComplexNDArrayInFortranOrderTest extends ComplexNDArrayTestBase with FortranOrderingForTest
+
+trait ComplexNDArrayTestBase extends FlatSpec with BeforeAndAfter{self:OrderingForTest =>
+  val current = Nd4j.ORDER
+
+  it should "work with ComplexNDArray correctly" in {
+
+    val complexNDArray =
+      Array(
+        Array(1 + i, 1 + i),
+        Array(1 + 3 * i, 1 + 3 * i)
+      ).toNDArray
+
+    val result = complexNDArray(0,0)
+
+    assert(result == 1 + i)
+
+    val result2 = complexNDArray(->,0)
+
+    assert(result2 == Array(Array(1 + i),Array(1 + 3*i)).toNDArray)
+  }
+
+
+  override protected def before(fun: => Any): Unit = {
+    Nd4j.ORDER = ordering.value
+  }
+
+  override protected def after(fun: => Any): Unit = {
+    Nd4j.ORDER = current
+  }
+}

--- a/src/test/scala/org/nd4s/OrderingForTest.scala
+++ b/src/test/scala/org/nd4s/OrderingForTest.scala
@@ -1,0 +1,14 @@
+package org.nd4s
+
+import org.scalatest.{Outcome, Suite, SuiteMixin}
+
+trait OrderingForTest extends SuiteMixin{this:Suite =>
+  val ordering:NDOrdering
+}
+trait COrderingForTest extends OrderingForTest{this:Suite =>
+  override val ordering: NDOrdering = NDOrdering.C
+}
+trait FortranOrderingForTest extends OrderingForTest{this:Suite =>
+  override val ordering: NDOrdering = NDOrdering.Fortran
+}
+


### PR DESCRIPTION
This PR allows INDArray to be extracted a value, not Scalar INDArray if indices are all specified in all dimensions.

```scala
scala> val m = Nd4j.create(2,2)
m: org.nd4j.linalg.api.ndarray.INDArray =
[[0.00,0.00]
 [0.00,0.00]]

scala> m(1,0)
res0: Double = 0.0
```