### PR TITLE
fixes #67, #69 / change XProjection behavior to Scala-Collectionish , add foreach API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sub: org.nd4j.linalg.api.ndarray.INDArray =
 | arr.sumT                                   | np.sum(arr)                                 | 45.0  //returns Double value                                   |
 | val comp = Array(1 + i, 1 + 2 * i).toNDArray | comp = np.array([1 + 1j, 1 + 2j])           | [1.0 + 1.0i ,1.0 + 2.0i]                                       |
 | comp.sumT                                  | np.sum(comp)                                | 2.0 + 3.0i //returns IComplexNumber value                      |
-| for(row <- arr.rowP if row.get(0) > 1) yield row*2 |   | [[1.00,2.00,3.00] [8.00,10.00,12.00] [14.00,16.00,18.00]] |
+| for(row <- arr.rowP if row.get(0) > 1) yield row*2 |   | [[8.00,10.00,12.00] [14.00,16.00,18.00]] |
 | val tensor = (1 to 8).asNDArray(2,2,2) | tensor = np.array([[[1, 2], [3, 4]],[[5,6],[7,8]]]) | [[[1.00,2.00] [3.00,4.00]] [[5.00,6.00] [7.00,8.00]]] |
-| for(slice <- tensor.sliceP if slice.get(0) > 1) yield slice*2 |  |[[[1.00,2.00] [3.00,4.00]] [[10.00,12.00] [14.00,16.00]]] |
-|arr(0 -> 3 by 2, ->) = 0                  |                 | [[0.00,0.00,0.00] [4.00,5.00,6.00] [0.00,0.00,0.00]] |
+| for(slice <- tensor.sliceP if slice.get(0) > 1) yield slice*2 |                           |[[[10.00,12.00][14.00,16.00]]] |
+|arr(0 -> 3 by 2, ->) = 0                  |                                                | [[0.00,0.00,0.00] [4.00,5.00,6.00] [0.00,0.00,0.00]] |

--- a/src/main/scala/org/nd4s/ColumnProjectedNDArray.scala
+++ b/src/main/scala/org/nd4s/ColumnProjectedNDArray.scala
@@ -1,6 +1,7 @@
 package org.nd4s
 
 import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.indexing.{NDArrayIndex, SpecifiedIndex}
 
 class ColumnProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def this(ndarray: INDArray){
@@ -11,7 +12,7 @@ class ColumnProjectedNDArray(val array:INDArray,filtered:Array[Int]){
     for{
       i <- filtered
     } array.putColumn(i,f(array.getColumn(i)))
-    array
+    array.get(NDArrayIndex.all(),new SpecifiedIndex(filtered:_*))
   }
 
   def map(f:INDArray => INDArray):INDArray = new ColumnProjectedNDArray(array.dup(),filtered).flatMapi(f)
@@ -19,6 +20,12 @@ class ColumnProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def flatMap(f:INDArray => INDArray):INDArray = map(f)
 
   def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def foreach(f:INDArray => Unit):Unit = {
+    for{
+      i <- filtered
+    } f(array.getColumn(i))
+  }
 
   def withFilter(f:INDArray => Boolean):ColumnProjectedNDArray = {
     val targets = for{

--- a/src/main/scala/org/nd4s/RowProjectedNDArray.scala
+++ b/src/main/scala/org/nd4s/RowProjectedNDArray.scala
@@ -1,6 +1,7 @@
 package org.nd4s
 
 import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.indexing.{SpecifiedIndex, NDArrayIndex}
 
 class RowProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def this(ndarray: INDArray){
@@ -11,7 +12,7 @@ class RowProjectedNDArray(val array:INDArray,filtered:Array[Int]){
     for{
       i <- filtered
     } array.putRow(i,f(array.getRow(i)))
-    array
+    array.get(new SpecifiedIndex(filtered:_*),NDArrayIndex.all())
   }
 
   def map(f:INDArray => INDArray):INDArray = new RowProjectedNDArray(array.dup(),filtered).mapi(f)
@@ -19,6 +20,12 @@ class RowProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def flatMap(f:INDArray => INDArray):INDArray = map(f)
 
   def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def foreach(f:INDArray => Unit):Unit = {
+    for{
+      i <- filtered
+    } f(array.getColumn(i))
+  }
 
   def withFilter(f:INDArray => Boolean):RowProjectedNDArray = {
     val targets = for{

--- a/src/main/scala/org/nd4s/SliceProjectedNDArray.scala
+++ b/src/main/scala/org/nd4s/SliceProjectedNDArray.scala
@@ -1,6 +1,7 @@
 package org.nd4s
 
 import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.indexing.{SpecifiedIndex, NDArrayIndex}
 
 class SliceProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def this(ndarray: INDArray){
@@ -11,7 +12,7 @@ class SliceProjectedNDArray(val array:INDArray,filtered:Array[Int]){
     for{
       i <- filtered
     } array.putSlice(i,f(array.slice(i)))
-    array
+    array.get(new SpecifiedIndex(filtered:_*) +: NDArrayIndex.allFor(array).init:_*)
   }
 
   def map(f:INDArray => INDArray):INDArray = new SliceProjectedNDArray(array.dup(),filtered).flatMapi(f)
@@ -19,6 +20,11 @@ class SliceProjectedNDArray(val array:INDArray,filtered:Array[Int]){
   def flatMap(f:INDArray => INDArray):INDArray = map(f)
 
   def flatMapi(f:INDArray => INDArray):INDArray = mapi(f)
+
+  def foreach(f:INDArray => Unit):Unit =
+    for{
+      i <- filtered
+    } f(array.slice(i))
 
   def withFilter(f:INDArray => Boolean):SliceProjectedNDArray = {
     val targets = for{


### PR DESCRIPTION
Please refer to README for XProjection map/flatMap behaviour change.

And adds `foreach` API.
```scala
val arr = (1 to 9).asNDArray(3,3)

//You can remove `yield` if it doesn't return a value.
for(row <- arr.rowP if row.get(0) > 1) println(row*2) 
```