### PR TITLE
Updated to 0.4-rc3.7 / modify travis yml to ignore latest nd4j snapshot build result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.mvn/
 script:
-  - git clone https://github.com/deeplearning4j/nd4j.git && cd nd4j/ && mvn clean install -DskipTests -Dmaven.javadoc.skip=true --quiet && cd ../
+  - ./nd4j_install.sh
   - sbt ++${TRAVIS_SCALA_VERSION} test
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,12 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M1"),
   name := "nd4s",
-  version := "0.4-rc3",
+  version := "0.4-rc3.7",
   organization := "org.nd4j",
   resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",
   libraryDependencies ++= Seq(
-    "org.nd4j" % "nd4j-api" % "0.4-rc3.7-SNAPSHOT",
-    "org.nd4j" % "nd4j-x86" % "0.4-rc3.7-SNAPSHOT" % Test,
+    "org.nd4j" % "nd4j-api" % "0.4-rc3.7",
+    "org.nd4j" % "nd4j-x86" % "0.4-rc3.7" % Test,
     "ch.qos.logback" % "logback-classic" %  "1.1.3" % Test,
     "org.scalatest" %% "scalatest" % "2.2.4" % Test cross CrossVersion.binaryMapped {
       case x if x startsWith "2.12" => "2.11"

--- a/nd4j_install.sh
+++ b/nd4j_install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+git clone https://github.com/deeplearning4j/nd4j.git && cd nd4j/ && mvn clean install -DskipTests -Dmaven.javadoc.skip=true --quiet && cd ../
+
+exit 0


### PR DESCRIPTION
- Updated to 0.4-rc3.7
- Try to install nd4j latest snapshot, but ignore nd4j installation result if current ND4S doesn't require SNAPSHOT nd4j version.