### PR TITLE
adds PropertyBasedTesting for matrix slicing, referring to Breeze DenseMatrix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,8 @@
 lazy val nd4jVersion = SettingKey[String]("nd4jVersion")
 
-def scalaTestDependency(v: String): ModuleID = "org.scalatest" %% "scalatest" % v
-
 lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M3"),
+  crossScalaVersions := Seq("2.10.6", "2.11.7"),
   name := "nd4s",
   version := "0.4-rc3.9-SNAPSHOT",
   organization := "org.nd4j",
@@ -13,15 +11,12 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies ++= Seq(
     "org.nd4j" % "nd4j-api" % nd4jVersion.value,
     "org.nd4j" % "nd4j-x86" % nd4jVersion.value % Test,
+    "org.scalatest" %% "scalatest" % "2.2.4" % Test,
     "ch.qos.logback" % "logback-classic" % "1.1.3" % Test,
     "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
     "org.scalanlp" %% "breeze" % "0.12" % Test,
     "com.github.julien-truffaut" %% "monocle-core" % "1.2.0" % Test
   ),
-  libraryDependencies <+= scalaVersion {
-    case x if x startsWith "2.12" => scalaTestDependency("2.2.5-M3")
-    case x => scalaTestDependency("2.2.4")
-  },
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"),
   publishMavenStyle := true,
   publishArtifact in Test := false,

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val nd4jVersion = SettingKey[String]("nd4jVersion")
 
-def scalaTestDependency(v:String):ModuleID = "org.scalatest" %% "scalatest" % v
+def scalaTestDependency(v: String): ModuleID = "org.scalatest" %% "scalatest" % v
 
 lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.7",
@@ -13,16 +13,19 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies ++= Seq(
     "org.nd4j" % "nd4j-api" % nd4jVersion.value,
     "org.nd4j" % "nd4j-x86" % nd4jVersion.value % Test,
-    "ch.qos.logback" % "logback-classic" %  "1.1.3" % Test
+    "ch.qos.logback" % "logback-classic" % "1.1.3" % Test,
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
+    "org.scalanlp" %% "breeze" % "0.12" % Test,
+    "com.github.julien-truffaut" %% "monocle-core" % "1.2.0" % Test
   ),
-  libraryDependencies <+= scalaVersion{
+  libraryDependencies <+= scalaVersion {
     case x if x startsWith "2.12" => scalaTestDependency("2.2.5-M3")
     case x => scalaTestDependency("2.2.4")
   },
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps"),
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  pomIncludeRepository := {_ => false},
+  pomIncludeRepository := { _ => false },
   publishTo <<= version {
     v =>
       val nexus = "https://oss.sonatype.org/"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/src/test/scala/org/nd4s/BreezeCheck.scala
+++ b/src/test/scala/org/nd4s/BreezeCheck.scala
@@ -1,0 +1,63 @@
+package org.nd4s
+
+import breeze.linalg._
+import monocle.Prism
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4s.Implicits._
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalatest.FlatSpec
+import org.scalatest.prop.Checkers
+
+/**
+  * Created by taisukeoe on 16/03/05.
+  */
+class BreezeCheck extends FlatSpec with Checkers {
+  it should "work as same as NDArray slicing" in {
+    check {
+      Prop.forAll {
+        (ndArray: INDArray) =>
+          ndArray.setOrder('f')
+          val shape = ndArray.shape()
+          val Array(row, col) = shape
+          Prop.forAll(Gen.choose(0, row - 1), Gen.choose(0, row - 1), Gen.choose(0, col - 1), Gen.choose(0, col - 1)) {
+            (r1, r2, c1, c2) =>
+              val rowRange = if (r1 > r2) r2 to r1 else r1 to r2
+              val columnRange = if (c1 > c2) c2 to c1 else c1 to c2
+              val slicedByND4S = ndArray(rowRange, columnRange)
+              val slicedByBreeze = prism.getOption(ndArray).map(dm => prism.reverseGet(dm(rowRange, columnRange)))
+              slicedByBreeze.contains(slicedByND4S)
+          }
+      }
+    }
+  }
+
+  //This supports only real value since ND4J drops complex number support temporary.
+  lazy val prism = Prism[INDArray, DenseMatrix[Double]] { ndArray =>
+    //Breeze DenseMatrix doesn't support tensor nor C order matrix.
+    if (ndArray.rank() > 2 || ndArray.ordering() == 'c')
+      None
+    else {
+      val shape = ndArray.shape()
+      val linear = ndArray.linearView()
+      val arr = (0 until ndArray.length()).map(linear.getDouble).toArray
+      Some(DenseMatrix(arr).reshape(shape(0), shape(1)))
+    }
+  } {
+    dm =>
+      val shape = Array(dm.rows, dm.cols)
+      dm.toArray.mkNDArray(shape, NDOrdering.Fortran)
+  }
+
+  implicit def arbNDArray: Arbitrary[INDArray] = Arbitrary {
+    for {
+      rows <- Gen.choose(1, 100)
+      columns <- Gen.choose(1, 100)
+    } yield {
+      val nd = Nd4j.rand(rows, columns)
+      nd.setOrder('f')
+      nd
+    }
+  }
+
+}

--- a/src/test/scala/org/nd4s/BreezeCheck.scala
+++ b/src/test/scala/org/nd4s/BreezeCheck.scala
@@ -26,7 +26,7 @@ class BreezeCheck extends FlatSpec with Checkers {
               val columnRange = if (c1 > c2) c2 to c1 else c1 to c2
               val slicedByND4S = ndArray(rowRange, columnRange)
               val slicedByBreeze = prism.getOption(ndArray).map(dm => prism.reverseGet(dm(rowRange, columnRange)))
-              slicedByBreeze.contains(slicedByND4S)
+              slicedByBreeze.exists(_ == slicedByND4S)
           }
       }
     }


### PR DESCRIPTION
Breeze owns well-tested DenseMatrix, which is two dimensional matrix in fortran ordering, with rich operations incl. indexing / slicing.
It would be also good reference to check if INDArray operations work properly in PropertyBasedTesting.

https://github.com/scalanlp/breeze

On the other hand, unfortunately Breeze (and Monocle for Prism between INDArray and DenseMatrix) don't support Scala 2.12.0-MX.
I think robust testing would be far more important than supporting Scala 2.12.0-M3 at this moment. So I would drop Scala 2.12.0-M3 support in ND4S.