### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ND4S: Scala bindings for ND4J
+# ND4S: Scala bindings for ND4J
 
 [![Join the chat at https://gitter.im/deeplearning4j/deeplearning4j](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deeplearning4j/deeplearning4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -67,7 +67,7 @@ sub: org.nd4j.linalg.api.ndarray.INDArray =
  [5.00,6.00]]
 ```
 
-#CheatSheet(WIP)
+# CheatSheet(WIP)
 
 | ND4S syntax                                | Equivalent NumPy syntax                     | Result                                                         |
 |--------------------------------------------|---------------------------------------------|----------------------------------------------------------------|


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
