### PR TITLE
Introduce SKIP_BUILD mode to perform-release.sh script

### DIFF
--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,9 +9,7 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=${3:-}
-if [[ -z ${SKIP_BUILD:-} ]]; then
-    SKIP_BUILD=0
-fi
+SKIP_BUILD=${SKIP_BUILD:-0}
 
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"
 echo "========================================================================================"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -31,12 +31,12 @@ if [[ "${SKIP_BUILD}" == "0" ]]; then
     sbt +publishSigned
 fi
 
-git commit -a -m "Update to version $RELEASE_VERSION"
-git tag -a -m "nd4s-$RELEASE_VERSION" "nd4s-$RELEASE_VERSION"
-git tag -a -f -m "nd4s-$RELEASE_VERSION" "latest_release"
+git commit -s -a -m "Update to version $RELEASE_VERSION"
+git tag -s -a -m "nd4s-$RELEASE_VERSION" "nd4s-$RELEASE_VERSION"
+git tag -s -a -f -m "nd4s-$RELEASE_VERSION" "latest_release"
 
 sed -i "s/\"currentVersion\", default = \".*\"/\"currentVersion\", default = \"$SNAPSHOT_VERSION\"/" build.sbt
 sed -i "s/\"nd4jVersion\", default = \".*\"/\"nd4jVersion\", default = \"$SNAPSHOT_VERSION\"/" build.sbt
-git commit -a -m "Update to version $SNAPSHOT_VERSION"
+git commit -s -a -m "Update to version $SNAPSHOT_VERSION"
 
 echo "Successfully performed release of version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,6 +9,9 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=${3:-}
+if [[ -z ${SKIP_BUILD:-} ]]; then
+    SKIP_BUILD=0
+fi
 
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"
 echo "========================================================================================"
@@ -18,21 +21,24 @@ if [[ ! -z $(git tag -l "nd4s-$RELEASE_VERSION") ]]; then
     exit 1
 fi
 
-sed -i "s/version := \".*\",/version := \"$RELEASE_VERSION\",/" build.sbt
-sed -i "s/nd4jVersion := \".*\",/nd4jVersion := \"$RELEASE_VERSION\",/" build.sbt
+sed -i "s/\"currentVersion\", default = \".*\"/\"currentVersion\", default = \"$RELEASE_VERSION\"/" build.sbt
+sed -i "s/\"nd4jVersion\", default = \".*\"/\"nd4jVersion\", default = \"$RELEASE_VERSION\"/" build.sbt
 
 # ~/.ivy2/.credentials needs to look like this:
 # realm=Sonatype Nexus Repository Manager
 # host=oss.sonatype.org
 # user=xxx
 # password=xxx
-sbt +publishSigned
+if [[ "${SKIP_BUILD}" == "0" ]]; then
+    sbt +publishSigned
+fi
 
 git commit -a -m "Update to version $RELEASE_VERSION"
 git tag -a -m "nd4s-$RELEASE_VERSION" "nd4s-$RELEASE_VERSION"
+git tag -a -f -m "nd4s-$RELEASE_VERSION" "latest_release"
 
-sed -i "s/version := \".*\",/version := \"$SNAPSHOT_VERSION\",/" build.sbt
-sed -i "s/nd4jVersion := \".*\",/nd4jVersion := \"$SNAPSHOT_VERSION\",/" build.sbt
+sed -i "s/\"currentVersion\", default = \".*\"/\"currentVersion\", default = \"$SNAPSHOT_VERSION\"/" build.sbt
+sed -i "s/\"nd4jVersion\", default = \".*\"/\"nd4jVersion\", default = \"$SNAPSHOT_VERSION\"/" build.sbt
 git commit -a -m "Update to version $SNAPSHOT_VERSION"
 
 echo "Successfully performed release of version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow updating the source code for a release before making the final build on the "latest_release" tag.

## How was this patch tested?

Build succeeds with source code modified by the script, with no reference to SNAPSHOT artifacts.